### PR TITLE
Turn single layer select into a debugging tool

### DIFF
--- a/RecoLocalCalo/HGCalRecHitDump/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecHitDump/interface/HGCalImagingAlgo.h
@@ -46,7 +46,8 @@ class HGCalImagingAlgo
   
   enum VerbosityLevel { pDEBUG = 0, pWARNING = 1, pINFO = 2, pERROR = 3 }; 
 
- HGCalImagingAlgo() : delta_c(0.), kappa(1.), ecut(0.), cluster_offset(0),
+ HGCalImagingAlgo() : layer_select(-1), delta_c(0.), kappa(1.), ecut(0.), 
+                      cluster_offset(0),
 		      geometry(0), ddd(0), 
 		      //topology(*thetopology_p), 
 		      algoId(reco::CaloCluster::undefined),
@@ -57,30 +58,38 @@ class HGCalImagingAlgo
 		   const HGCalGeometry *thegeometry_p,
 		   //		   const CaloSubdetectorTopology *thetopology_p,
 		   reco::CaloCluster::AlgoId algoId_in,
-		   VerbosityLevel the_verbosity = pERROR) : delta_c(delta_c_in), kappa(kappa_in), 
-							    ecut(ecut_in),    
-							    cluster_offset(0),
-							    sigma2(1.0),
-							    geometry(thegeometry_p), 
-							    //topology(*thetopology_p), 
-							    algoId(algoId_in),
-							    verbosity(the_verbosity){
-  }
+		   VerbosityLevel the_verbosity = pERROR,
+		   int dbglayer = -1) : 
+    layer_select(dbglayer),
+    delta_c(delta_c_in), 
+    kappa(kappa_in), 
+    ecut(ecut_in),    
+    cluster_offset(0),
+    sigma2(1.0),
+    geometry(thegeometry_p), 
+    //topology(*thetopology_p), 
+    algoId(algoId_in),
+    verbosity(the_verbosity){
+    }
   
   HGCalImagingAlgo(float delta_c_in, double kappa_in, double ecut_in,
 		   double showerSigma, 
 		   const HGCalGeometry *thegeometry_p,
 		   //		   const CaloSubdetectorTopology *thetopology_p,
 		   reco::CaloCluster::AlgoId algoId_in,
-		   VerbosityLevel the_verbosity = pERROR) : delta_c(delta_c_in), kappa(kappa_in), 
-							    ecut(ecut_in),    
-							    cluster_offset(0),
-							    sigma2(std::pow(showerSigma,2.0)),
-							    geometry(thegeometry_p), 
-							    //topology(*thetopology_p), 
-							    algoId(algoId_in),
-							    verbosity(the_verbosity){
-  }
+		   VerbosityLevel the_verbosity = pERROR,
+		   int dbglayer = -1) : 
+    layer_select(dbglayer),
+    delta_c(delta_c_in), 
+    kappa(kappa_in), 
+    ecut(ecut_in),    
+    cluster_offset(0),
+    sigma2(std::pow(showerSigma,2.0)),
+    geometry(thegeometry_p), 
+    //topology(*thetopology_p), 
+    algoId(algoId_in),
+    verbosity(the_verbosity){
+    }
 
   virtual ~HGCalImagingAlgo()
     {
@@ -111,6 +120,7 @@ class HGCalImagingAlgo
   
   //max number of layers
   static const unsigned int maxlayer = 39;
+  const int layer_select; // for debugging
 
   // The two parameters used to identify clusters
   float delta_c;

--- a/RecoLocalCalo/HGCalRecHitDump/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecHitDump/src/HGCalImagingAlgo.cc
@@ -26,9 +26,7 @@ namespace seezview {
 // Create a vector of Hexels associated to one cluster from a collection of HGCalRecHits - this can be used 
 // directly to make the final cluster list - this method can be invoked multiple times for the same event 
 // with different input (reset should be called between events)
-void HGCalImagingAlgo::makeClusters(const HGCRecHitCollection& hits)
-
-{
+void HGCalImagingAlgo::makeClusters(const HGCRecHitCollection& hits) {
 
   const HGCalDDDConstants* ddd = &(geometry->topology().dddConstants());
 
@@ -61,8 +59,8 @@ void HGCalImagingAlgo::makeClusters(const HGCRecHitCollection& hits)
 
     int layer = HGCalDetId(detid).layer()+int(HGCalDetId(detid).zside()>0)*(maxlayer+1);
     
-    const int layer_select = 5;
-    if( layer != layer_select && 
+    if( layer_select != -1 && 
+	layer != layer_select && 
 	layer != int(layer_select + int(HGCalDetId(detid).zside()>0)*(maxlayer+1)) ) continue;
 
     // determine whether this is a half-hexagon


### PR DESCRIPTION
Allow the user to determine if a single layer in the HGCal is clustered.
This could be useful for studies as things progress.

Default behavior is to run the single layer clustering on all layers passed to the imagine algorithm.
