### PR TITLE
Fix energy scale for physics list FTFP_BERT_EMM

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
@@ -14,13 +14,14 @@ class HGCalDepthPreClusterer
 {
 public:
   
- HGCalDepthPreClusterer() : radius(0.), minClusters(0.), clusterTools(nullptr)
+ HGCalDepthPreClusterer() : radius(0.), minClusters(0.), realSpaceCone(false), clusterTools(nullptr)
     {
   }
   
- HGCalDepthPreClusterer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes, double radius_in, uint32_t min_clusters) : 
+ HGCalDepthPreClusterer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes, double radius_in, uint32_t min_clusters, bool real_space_cone) : 
   radius(radius_in),
   minClusters(min_clusters),
+  realSpaceCone(real_space_cone),
   clusterTools(std::make_unique<hgcal::ClusterTools>(conf,sumes)) {
   }
 
@@ -35,6 +36,7 @@ public:
 private:  
   float radius;
   uint32_t minClusters;
+  bool realSpaceCone;
   
   std::unique_ptr<hgcal::ClusterTools> clusterTools;
 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -194,6 +194,7 @@ class HGCalImagingAlgo
   //@@EM todo: the number of layers should be obtained programmatically - the range is 1-n instead of 0-n-1...
 
   //these functions should be in a helper class.
+  double distance2(const Hexel &pt1, const Hexel &pt2); //distance squared
   double distance(const Hexel &pt1, const Hexel &pt2); //2-d distance on the layer (x-y)
   double calculateLocalDensity(std::vector<KDNode> &, KDTree &); //return max density
   double calculateDistanceToHigher(std::vector<KDNode> &, KDTree &);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
@@ -17,9 +17,14 @@ namespace {
     return idx;
   } 
 
-  float dist(const edm::Ptr<reco::BasicCluster> &a, 
+  float dist2(const edm::Ptr<reco::BasicCluster> &a, 
+	      const edm::Ptr<reco::BasicCluster> &b) {
+    return reco::deltaR2(*a,*b);
+  }  
+
+  float distReal2(const edm::Ptr<reco::BasicCluster> &a, 
              const edm::Ptr<reco::BasicCluster> &b) {
-    return reco::deltaR(*a,*b);
+    return (a->x()-b->x())*(a->x()-b->x()) + (a->y()-b->y())*(a->y()-b->y());
   }
 }
 
@@ -29,6 +34,8 @@ std::vector<reco::HGCalMultiCluster> HGCalDepthPreClusterer::makePreClusters(con
   std::vector<size_t> es = sorted_indices(thecls);
   std::vector<int> vused(es.size(),0);
   unsigned int used = 0;
+  const float radius2 = radius*radius;
+
   for(unsigned int i = 0; i < es.size(); ++i) {
     if(vused[i]==0) {
       reco::HGCalMultiCluster temp;      
@@ -37,7 +44,10 @@ std::vector<reco::HGCalMultiCluster> HGCalDepthPreClusterer::makePreClusters(con
       ++used;
       for(unsigned int j = i+1; j < es.size(); ++j) {
 	if(vused[j]==0) {
-	  if( dist(thecls[es[i]],thecls[es[j]])<radius && int(thecls[es[i]]->z()*vused[i])>0 ) {
+          float distanceCheck = 9999.;
+          if( realSpaceCone ) distanceCheck = distReal2(thecls[es[i]],thecls[es[j]]);
+          else distanceCheck = dist2(thecls[es[i]],thecls[es[j]]);
+	  if( distanceCheck<radius2 && int(thecls[es[i]]->z()*vused[i])>0 ) {
 	    temp.push_back(thecls[es[j]]);
 	    vused[j]=vused[i];
 	    ++used;

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -172,9 +172,13 @@ math::XYZPoint HGCalImagingAlgo::calculatePosition(std::vector<KDNode> &v){
 } 
 
 double HGCalImagingAlgo::distance(const Hexel &pt1, const Hexel &pt2){
+  return std::sqrt(distance2(pt1,pt2));
+}
+
+double HGCalImagingAlgo::distance2(const Hexel &pt1, const Hexel &pt2){
   const double dx = pt1.x - pt2.x;
   const double dy = pt1.y - pt2.y;
-  return std::sqrt(dx*dx + dy*dy);
+  return (dx*dx + dy*dy);
 }
 
 
@@ -209,23 +213,23 @@ double HGCalImagingAlgo::calculateDistanceToHigher(std::vector<KDNode> &nd, KDTr
     maxdensity = nd[rs[0]].data.rho;
   else
     return maxdensity; // there are no hits
-  double dist = 50.0;
+  double dist2 = 2500.0;
   //start by setting delta for the highest density hit to 
   //the most distant hit - this is a convention
 
   for(unsigned int j = 0; j < nd.size(); j++){
-    double tmp = distance(nd[rs[0]].data, nd[j].data);
-    dist = tmp > dist ? tmp : dist;
+    double tmp = distance2(nd[rs[0]].data, nd[j].data);
+    dist2 = tmp > dist2 ? tmp : dist2;
   }
-  nd[rs[0]].data.delta = dist;
+  nd[rs[0]].data.delta = std::sqrt(dist2);
   nd[rs[0]].data.nearestHigher = nearestHigher;
 
   //now we save the largest distance as a starting point
   
-  double max_dist = dist;
+  const double max_dist2 = dist2;
   
   for(unsigned int oi = 1; oi < nd.size(); ++oi){ // start from second-highest density
-    dist = max_dist;
+    dist2 = max_dist2;
     unsigned int i = rs[oi];
     // we only need to check up to oi since hits 
     // are ordered by decreasing density
@@ -233,13 +237,13 @@ double HGCalImagingAlgo::calculateDistanceToHigher(std::vector<KDNode> &nd, KDTr
     // and the ones AFTER to have lower rho
     for(unsigned int oj = 0; oj < oi; oj++){ 
       unsigned int j = rs[oj];
-      double tmp = distance(nd[i].data, nd[j].data);
-      if(tmp <= dist){ //this "<=" instead of "<" addresses the (rare) case when there are only two hits
-	dist = tmp;
+      double tmp = distance2(nd[i].data, nd[j].data);
+      if(tmp <= dist2){ //this "<=" instead of "<" addresses the (rare) case when there are only two hits
+	dist2 = tmp;
 	nearestHigher = j;
       }
     }
-    nd[i].data.delta = dist;
+    nd[i].data.delta = std::sqrt(dist2);
     nd[i].data.nearestHigher = nearestHigher; //this uses the original unsorted hitlist 
   }
   return maxdensity;

--- a/RecoLocalCalo/HGCalRecProducers/plugins/HGCalClusterTestProducer.cc
+++ b/RecoLocalCalo/HGCalRecProducers/plugins/HGCalClusterTestProducer.cc
@@ -62,6 +62,7 @@ HGCalClusterTestProducer::HGCalClusterTestProducer(const edm::ParameterSet &ps) 
   double kappa = ps.getParameter<double>("kappa");
   double multicluster_radius = ps.getParameter<double>("multiclusterRadius");
   double minClusters = ps.getParameter<unsigned>("minClusters");
+  bool realSpaceCone = ps.getParameter<bool>("realSpaceCone");
   
   
   if(detector=="all") {
@@ -90,7 +91,7 @@ HGCalClusterTestProducer::HGCalClusterTestProducer(const edm::ParameterSet &ps) 
 
   auto sumes = consumesCollector();
 
-  multicluster_algo = std::make_unique<HGCalDepthPreClusterer>(ps, sumes, multicluster_radius, minClusters);
+  multicluster_algo = std::make_unique<HGCalDepthPreClusterer>(ps, sumes, multicluster_radius, minClusters, realSpaceCone);
 
   // hydraTokens[0] = consumes<std::vector<reco::PFCluster> >( edm::InputTag("FakeClusterGen") );
   // hydraTokens[1] = consumes<std::vector<reco::PFCluster> >( edm::InputTag("FakeClusterCaloFace") );

--- a/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py
@@ -79,8 +79,8 @@ HGCalRecHit = cms.EDProducer(
 
     # EM Scale calibrations
     layerWeights = dEdX_weights,
-    thicknessCorrection = cms.vdouble(0.964,0.920,0.909), # 100, 200, 300 um
-    
+    thicknessCorrection = cms.vdouble(1.132,1.092,1.084), # 100, 200, 300 um 
+
     # algo
     algo = cms.string("HGCalRecHitWorkerSimple")
     

--- a/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cfi.py
+++ b/RecoLocalCalo/HGCalRecProducers/python/hgcalLayerClusters_cfi.py
@@ -11,6 +11,7 @@ hgcalLayerClusters =  cms.EDProducer(
     ecut = cms.double(0.01),
     kappa = cms.double(10.),
     multiclusterRadius = cms.double(0.015),
+    realSpaceCone = cms.bool(False),
     minClusters = cms.uint32(3),
     verbosity = cms.untracked.uint32(3),
     HGCEEInput = cms.InputTag('HGCalRecHit:HGCEERecHits'),


### PR DESCRIPTION
The only change is in the configuration RecoLocalCalo/HGCalRecProducers/python/HGCalRecHit_cfi.py

The energy scale is corrected to account for the change in the physics list, following what presented and discussed in https://indico.cern.ch/event/607331/contributions/2453642/attachments/1401757/2139714/SimAndPerf_25Jan17.pdf
