### PR TITLE
Imaging threshold modif

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalImagingAlgo.h
@@ -50,7 +50,7 @@ class HGCalImagingAlgo
  HGCalImagingAlgo() : vecDeltas(), kappa(1.), ecut(0.), cluster_offset(0),
 		      sigma2(1.0),
 		      algoId(reco::CaloCluster::undefined),
-		      verbosity(pERROR){
+                      verbosity(pERROR),initialized(false){
  }
 
   HGCalImagingAlgo(std::vector<double> vecDeltas_in, double kappa_in, double ecut_in,
@@ -76,6 +76,7 @@ class HGCalImagingAlgo
                                                             nonAgedNoises(nonAgedNoises_in),
                                                             noiseMip(noiseMip_in),
 							    verbosity(the_verbosity),
+                                                            initialized(false),
 							    points(2*(maxlayer+1)),
 							    minpos(2*(maxlayer+1),{ {0.0f,0.0f} }),
 							    maxpos(2*(maxlayer+1),{ {0.0f,0.0f} }),
@@ -107,6 +108,7 @@ class HGCalImagingAlgo
                                                             nonAgedNoises(nonAgedNoises_in),
                                                             noiseMip(noiseMip_in),
 							    verbosity(the_verbosity),
+                                                            initialized(false),
 							    points(2*(maxlayer+1)),
 							    minpos(2*(maxlayer+1),{ {0.0f,0.0f} }),
 							    maxpos(2*(maxlayer+1),{ {0.0f,0.0f} }),
@@ -148,6 +150,8 @@ class HGCalImagingAlgo
 	maxpos[i][0]=0.;maxpos[i][1]=0.;
       }
   }
+  void computeThreshold();
+
   /// point in the space
   typedef math::XYZPoint Point;
 
@@ -185,11 +189,14 @@ class HGCalImagingAlgo
   double fcPerEle;
   std::vector<double> nonAgedNoises;
   double noiseMip;
+  std::vector<std::vector<double> >thresholds;
 
   // The verbosity level
   VerbosityLevel verbosity;
 
-  
+  // initialized
+  bool initialized;
+
   struct Hexel {
 
     double x;

--- a/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h
@@ -44,6 +44,7 @@ namespace hgcal {
     float getPhi(const DetId& id) const;
     float getPt(const DetId& id, const float& hitEnergy, const float& vertex_z = 0.) const;
 
+    inline const CaloGeometry * getGeometry() const {return geom_;};
   private:
     const CaloGeometry* geom_;
   };

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalImagingAlgo.cc
@@ -4,6 +4,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 
 #include "RecoEcal/EgammaCoreTools/interface/PositionCalc.h"
 //
@@ -12,27 +13,22 @@
 
 void HGCalImagingAlgo::populate(const HGCRecHitCollection& hits){
   //loop over all hits and create the Hexel structure, skip energies below ecut
+  computeThreshold();
+  
   for (unsigned int i=0;i<hits.size();++i) {
     const HGCRecHit& hgrh = hits[i];
     DetId detid = hgrh.detid();
     int layer = rhtools_.getLayerWithOffset(detid);
     float thickness = -9999.;
-    unsigned thickIndex = -1;
     float sigmaNoise = -9999.;
     if(dependSensor){
-      if( layer <= 40 ) {
+      if (layer<= 40)
 	thickness = rhtools_.getSiThickness(detid);
-	if( thickness>99. && thickness<101.) thickIndex=0;
-	else if( thickness>199. && thickness<201. ) thickIndex=1;
-	else if( thickness>299. && thickness<301. ) thickIndex=2;
-	else assert( thickIndex>0 && "ERROR - silicon thickness has a nonsensical value" );
-      }
-      if( layer <= 40 ) sigmaNoise = 0.001 * fcPerEle * nonAgedNoises[thickIndex] * dEdXweights[layer] / (fcPerMip[thickIndex] * thicknessCorrection[thickIndex]);
-      else if( layer <=52 ) sigmaNoise = 0.001 * noiseMip * dEdXweights[layer];
-      if(hgrh.energy() < ecut*sigmaNoise) continue; //this sets the ZS threshold at ecut times the sigma noise for the sensor
+      HGCalDetId hgDetId(detid);
+      double storedThreshold=thresholds[layer-1][layer<=40 ? hgDetId.wafer() : 0];
+      if(hgrh.energy() <  storedThreshold) continue; //this sets the ZS threshold at ecut times the sigma noise for the sensor
     }
     if(!dependSensor && hgrh.energy() < ecut) continue; 
-
 
     layer += int(HGCalDetId(detid).zside()>0)*(maxlayer+1);
     
@@ -560,4 +556,57 @@ void HGCalImagingAlgo::shareEnergy(const std::vector<KDNode>& incluster,
     diff = std::sqrt(diff2);
     //std::cout << " iteration = " << iter << " diff = " << diff << std::endl;
   } 
+}
+
+void HGCalImagingAlgo::computeThreshold() {
+
+  if(initialized) return;
+  const std::vector<DetId>& listee(rhtools_.getGeometry()->getValidDetIds(DetId::Forward,ForwardSubdetector::HGCEE));
+  const std::vector<DetId>& listfh(rhtools_.getGeometry()->getValidDetIds(DetId::Forward,ForwardSubdetector::HGCHEF));
+  //  const std::vector<DetId>& listbh(rhtools_.getGeometry()->getValidDetIds(DetId::Hcal,HcalSubdetector::HcalEndcap));
+  
+  std::vector<double> dummy;
+  dummy.resize(700,0);
+  thresholds.resize(52,dummy);
+  float thickness=-9999;
+  unsigned thickIndex = -1;
+  float sigmaNoise = -9999.;
+  int previouswafer=-999;
+  int layer = -999;
+  int wafer=-999;
+
+  for(unsigned icalo=0;icalo<2;++icalo) 
+    {
+      const std::vector<DetId>& listDetId( icalo==0 ? listee : listfh);
+      unsigned nDetIds=listDetId.size();
+
+      for(unsigned i=0;i<nDetIds;++i) 
+	{
+	  HGCalDetId detid = listDetId[i];
+	  wafer=detid.wafer();
+	  if(wafer==previouswafer) continue;
+	  previouswafer=detid.wafer();
+	  // no need to do it twice
+	  if(detid.zside()<0) continue;
+	  layer = rhtools_.getLayerWithOffset(detid);
+
+	  thickness = rhtools_.getSiThickness(detid);
+	  if( thickness>99. && thickness<101.) thickIndex=0;
+	  else if( thickness>199. && thickness<201. ) thickIndex=1;
+	  else if( thickness>299. && thickness<301. ) thickIndex=2;
+	  else assert( thickIndex>0 && "ERROR - silicon thickness has a nonsensical value" );
+	  sigmaNoise = 0.001 * fcPerEle * nonAgedNoises[thickIndex] * dEdXweights[layer] / (fcPerMip[thickIndex] * thicknessCorrection[thickIndex]);
+	  thresholds[layer-1][wafer]=sigmaNoise*ecut;
+	}
+    }
+
+  // now BH, much faster
+  for ( unsigned ilayer=layer+1;ilayer<=52;++ilayer)
+    {
+      sigmaNoise = 0.001 * noiseMip * dEdXweights[ilayer];
+      dummy.clear();
+      dummy.push_back(sigmaNoise*ecut);
+      thresholds[ilayer-1]=dummy;
+    }
+  initialized=true;
 }


### PR DESCRIPTION
This is a copy of #11 - @beaudett, I'll try to get all the changes into cms-sw/cmssw, but your PR won't merge into the updated branch. Could you have a look if you can change your code such that is merges with the `91X` branch of CMS-HGCAL/cmssw (which is what this PR tries to do)?

Quoting from before:
This PR consists in moving out from the "populate()" method the piece of code that computes the energy thresholds.
Now, these thresholds are computed once for all when the method is called the first time. They are stored in a vector<vector >. The first vector is for the layers, the second for the wafers.
Ultimately, it would be nice of the populate() method could be turned into a stand-alone class so that one doesn't have to re-code or copy the code to produce the Kd-trees.
I was hoping that this change would save CPU time; but I couldn't see any difference.