### PR TITLE
Add variant of CloseBy particle gun with configurable ∆R parameter.

### DIFF
--- a/IOMC/ParticleGuns/interface/CloseByFlatDeltaRGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByFlatDeltaRGunProducer.h
@@ -29,7 +29,7 @@ namespace edm {
     int fNParticles;
 
     // flag that denotes that exactly the particles defined by fPartIds should be shot, with that order and quantity
-    bool fShootPartIDs;
+    bool fExactShoot;
 
     // flag that denotes whether a random number of particles in the range [1, fNParticles] is shot
     bool fRandomShoot;

--- a/IOMC/ParticleGuns/interface/CloseByFlatDeltaRGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByFlatDeltaRGunProducer.h
@@ -1,57 +1,74 @@
 /*
  * Particle gun that can be positioned in space given ranges in rho, z and phi.
- *
- * Authors:
- *   - Marcel Rieger <marcel.rieger@cern.ch>
- *   - Gerrit van Onsem <gerrit.van.onsem@cern.ch>
  */
 
 #ifndef IOMC_PARTICLEGUN_CLOSEBYFLATDELTARGUNPRODUCER_H
 #define IOMC_PARTICLEGUN_CLOSEBYFLATDELTARGUNPRODUCER_H
 
-#include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+
+#include "HepMC/GenEvent.h"
+#include "HepPDT/ParticleDataTable.hh"
 
 namespace edm {
 
-  class CloseByFlatDeltaRGunProducer : public BaseFlatGunProducer {
+  class CloseByFlatDeltaRGunProducer : public one::EDProducer<one::WatchRuns, EndRunProducer> {
   public:
+    static void fillDescriptions(edm::ConfigurationDescriptions&);
+
     explicit CloseByFlatDeltaRGunProducer(const ParameterSet&);
     ~CloseByFlatDeltaRGunProducer() override;
+    void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    void endRun(const edm::Run&, const edm::EventSetup&) override;
+    void endRunProduce(edm::Run&, const edm::EventSetup&) override;
 
   private:
-    void produce(Event& e, const EventSetup& es) override;
+    void produce(Event&, const EventSetup&) override;
 
   protected:
     // ids of particles to shoot
-    std::vector<int> fPartIDs;
+    std::vector<int> particleIDs_;
 
     // the number of particles to shoot
-    int fNParticles;
+    int nParticles_;
 
     // flag that denotes that exactly the particles defined by fPartIds should be shot, with that order and quantity
-    bool fExactShoot;
+    bool exactShoot_;
 
     // flag that denotes whether a random number of particles in the range [1, fNParticles] is shot
-    bool fRandomShoot;
+    bool randomShoot_;
 
     // energy range
-    double fEnMin;
-    double fEnMax;
+    double eMin_;
+    double eMax_;
 
     // range of longitudinal gun position
-    double fZMin;
-    double fZMax;
+    double zMin_;
+    double zMax_;
 
     // range of radial gun position
-    double fRhoMin;
-    double fRhoMax;
+    double rhoMin_;
+    double rhoMax_;
 
     // phi range
-    double fPhiMin;
-    double fPhiMax;
+    double phiMin_;
+    double phiMax_;
 
     // deltaR parameters
-    double fDeltaR;
+    double deltaRMin_;
+    double deltaRMax_;
+
+    // debug flag
+    bool debug_;
+
+    // pointer to the current event
+    HepMC::GenEvent* genEvent_;
+
+    // pdg table
+    ESHandle<HepPDT::ParticleDataTable> pdgTable_;
   };
 
 }  // namespace edm

--- a/IOMC/ParticleGuns/interface/CloseByFlatDeltaRGunProducer.h
+++ b/IOMC/ParticleGuns/interface/CloseByFlatDeltaRGunProducer.h
@@ -1,0 +1,59 @@
+/*
+ * Particle gun that can be positioned in space given ranges in rho, z and phi.
+ *
+ * Authors:
+ *   - Marcel Rieger <marcel.rieger@cern.ch>
+ *   - Gerrit van Onsem <gerrit.van.onsem@cern.ch>
+ */
+
+#ifndef IOMC_PARTICLEGUN_CLOSEBYFLATDELTARGUNPRODUCER_H
+#define IOMC_PARTICLEGUN_CLOSEBYFLATDELTARGUNPRODUCER_H
+
+#include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
+
+namespace edm {
+
+  class CloseByFlatDeltaRGunProducer : public BaseFlatGunProducer {
+  public:
+    explicit CloseByFlatDeltaRGunProducer(const ParameterSet&);
+    ~CloseByFlatDeltaRGunProducer() override;
+
+  private:
+    void produce(Event& e, const EventSetup& es) override;
+
+  protected:
+    // ids of particles to shoot
+    std::vector<int> fPartIDs;
+
+    // the number of particles to shoot
+    int fNParticles;
+
+    // flag that denotes that exactly the particles defined by fPartIds should be shot, with that order and quantity
+    bool fShootPartIDs;
+
+    // flag that denotes whether a random number of particles in the range [1, fNParticles] is shot
+    bool fRandomShoot;
+
+    // energy range
+    double fEnMin;
+    double fEnMax;
+
+    // range of longitudinal gun position
+    double fZMin;
+    double fZMax;
+
+    // range of radial gun position
+    double fRhoMin;
+    double fRhoMax;
+
+    // phi range
+    double fPhiMin;
+    double fPhiMax;
+
+    // deltaR parameters
+    double fDeltaR;
+  };
+
+}  // namespace edm
+
+#endif  // IOMC_PARTICLEGUN_CLOSEBYFLATDELTARGUNPRODUCER_H

--- a/IOMC/ParticleGuns/src/CloseByFlatDeltaRGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByFlatDeltaRGunProducer.cc
@@ -1,0 +1,157 @@
+#include <ostream>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "DataFormats/Math/interface/Vector3D.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+#include "IOMC/ParticleGuns/interface/CloseByFlatDeltaRGunProducer.h"
+
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+using namespace edm;
+using namespace std;
+
+CloseByFlatDeltaRGunProducer::CloseByFlatDeltaRGunProducer(const ParameterSet& pset) : BaseFlatGunProducer(pset) {
+  ParameterSet gunParams = pset.getParameter<ParameterSet>("PGunParameters");
+
+  fPartIDs = gunParams.getParameter<vector<int> >("PartID");
+  fNParticles = gunParams.getParameter<int>("NParticles");
+  fShootPartIDs = gunParams.getParameter<bool>("ShootPartIDs");
+  fRandomShoot = gunParams.getParameter<bool>("RandomShoot");
+
+  fEnMax = gunParams.getParameter<double>("EnMax");
+  fEnMin = gunParams.getParameter<double>("EnMin");
+  fRhoMax = gunParams.getParameter<double>("RhoMax");
+  fRhoMin = gunParams.getParameter<double>("RhoMin");
+  fZMax = gunParams.getParameter<double>("ZMax");
+  fZMin = gunParams.getParameter<double>("ZMin");
+  fPhiMin = gunParams.getParameter<double>("MinPhi");
+  fPhiMax = gunParams.getParameter<double>("MaxPhi");
+  fDeltaR = gunParams.getParameter<double>("DeltaR");
+
+  produces<HepMCProduct>("unsmeared");
+  produces<GenEventInfoProduct>();
+}
+
+CloseByFlatDeltaRGunProducer::~CloseByFlatDeltaRGunProducer() {}
+
+void CloseByFlatDeltaRGunProducer::produce(Event& event, const EventSetup& setup) {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  CLHEP::HepRandomEngine* engine = &(rng->getEngine(event.streamID()));
+
+  if (fVerbosity > 0) {
+    LogDebug("CloseByFlatDeltaRGunProducer") << " : Begin New Event Generation" << endl;
+  }
+
+  // create a new event to fill
+  fEvt = new HepMC::GenEvent();
+
+  // determine gun parameters for first particle to shoot (postfixed with "0")
+  double phi = CLHEP::RandFlat::shoot(engine, fPhiMin, fPhiMax);
+  double rho = CLHEP::RandFlat::shoot(engine, fRhoMin, fRhoMax);
+  double z = CLHEP::RandFlat::shoot(engine, fZMin, fZMax);
+  double eta = -log(tan(0.5 * atan(rho / z)));
+  double phi0 = phi;
+  double eta0 = eta;
+
+  // determine the number of particles to shoot
+  int n = 0;
+  if (fShootPartIDs) {
+    n = (int)fPartIDs.size();
+  } else if (fRandomShoot) {
+    n = CLHEP::RandFlat::shoot(engine, 1, fNParticles + 1);
+  } else {
+    n = fNParticles;
+  }
+
+  // shoot particles
+  for (int i = 0; i < n; i++) {
+    // find a new position relative to the first particle, obviously for all but the first one
+    if (i > 0) {
+      // create a random deltaR up to fDeltaR
+      double deltaR = CLHEP::RandFlat::shoot(engine, 0., fDeltaR);
+
+      // split delta R randomly in phi and eta directions
+      double alpha = CLHEP::RandFlat::shoot(engine, 0., 2. * pi);
+      double deltaPhi = sin(alpha) * deltaR;
+      double deltaEta = cos(alpha) * deltaR;
+
+      // update phi
+      phi = phi0 + deltaPhi;
+
+      // update rho
+      // the approach is to transorm a difference in eta to a difference in rho using:
+      // 1. tan(theta) = rho / z       <=> rho   = z * tan(theta)
+      // 2. eta = -log(tan(theta / 2)) <=> theta = 2 * atan(exp(-eta))
+      // 2. in 1.                       => rho   = z * tan(2 * atan(exp(-eta)))
+      // using tan(atan(2 * x)) = - 2 * x (x^2 - 1) leads to
+      //                                =>  rho = -2 * z * x / (x^2 - 1), with x = exp(-eta)
+      // for eta = eta0 + deltaEta, this allows for defining x = exp(-(eta0 + deltaEta))
+      eta = eta0 + deltaEta;
+      double x = exp(-eta);
+      rho = -2 * z * x / (x * x - 1);
+    }
+
+    // compute the gun / vertex position
+    // the time offset is given in c*t and is used later on in the digitization
+    double x = rho * cos(phi);
+    double y = rho * sin(phi);
+    double timeOffset = sqrt(x * x + y * y + z * z) * cm / c_light;
+    HepMC::GenVertex* vtx = new HepMC::GenVertex(HepMC::FourVector(x * cm, y * cm, z * cm, timeOffset * c_light));
+
+    // obtain kinematics
+    int id = fShootPartIDs ? fPartIDs[i] : CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size());
+    const HepPDT::ParticleData* pData = fPDGTable->particle(HepPDT::ParticleID(abs(id)));
+    double e = CLHEP::RandFlat::shoot(engine, fEnMin, fEnMax);
+    double m = pData->mass().value();
+    double p = sqrt(e * e - m * m);
+
+    // determine momentum vector, that should point in the direction defined between
+    // (0,0,0) and the gun position with a length of p
+    math::XYZVector direction(x, y, z);
+    math::XYZVector pVec = direction.unit() * p;
+
+    // create the GenParticle
+    HepMC::FourVector fVec(pVec.x(), pVec.y(), pVec.z(), e);
+    HepMC::GenParticle* particle = new HepMC::GenParticle(fVec, id, 1);
+    particle->suggest_barcode(i + 1);
+
+    // add the particle to the vertex and the vertex to the event
+    vtx->add_particle_out(particle);
+    fEvt->add_vertex(vtx);
+
+    if (fVerbosity > 0) {
+      vtx->print();
+      particle->print();
+    }
+  }
+
+  // fill event attributes
+  fEvt->set_event_number(event.id().event());
+  fEvt->set_signal_process_id(20);
+
+  if (fVerbosity > 0) {
+    fEvt->print();
+  }
+
+  // store outputs
+  unique_ptr<HepMCProduct> BProduct(new HepMCProduct());
+  BProduct->addHepMCData(fEvt);
+  event.put(std::move(BProduct), "unsmeared");
+  unique_ptr<GenEventInfoProduct> genEventInfo(new GenEventInfoProduct(fEvt));
+  event.put(std::move(genEventInfo));
+
+  if (fVerbosity > 0) {
+    LogDebug("CloseByFlatDeltaRGunProducer") << " : Event Generation Done " << endl;
+  }
+}

--- a/IOMC/ParticleGuns/src/CloseByFlatDeltaRGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByFlatDeltaRGunProducer.cc
@@ -110,7 +110,7 @@ void CloseByFlatDeltaRGunProducer::produce(Event& event, const EventSetup& setup
     HepMC::GenVertex* vtx = new HepMC::GenVertex(HepMC::FourVector(x * cm, y * cm, z * cm, timeOffset * c_light));
 
     // obtain kinematics
-    int id = fExactShoot ? fPartIDs[i] : CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size());
+    int id = fPartIDs[fExactShoot ? i : CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size())];
     const HepPDT::ParticleData* pData = fPDGTable->particle(HepPDT::ParticleID(abs(id)));
     double e = CLHEP::RandFlat::shoot(engine, fEnMin, fEnMax);
     double m = pData->mass().value();

--- a/IOMC/ParticleGuns/src/CloseByFlatDeltaRGunProducer.cc
+++ b/IOMC/ParticleGuns/src/CloseByFlatDeltaRGunProducer.cc
@@ -26,7 +26,7 @@ CloseByFlatDeltaRGunProducer::CloseByFlatDeltaRGunProducer(const ParameterSet& p
 
   fPartIDs = gunParams.getParameter<vector<int> >("PartID");
   fNParticles = gunParams.getParameter<int>("NParticles");
-  fShootPartIDs = gunParams.getParameter<bool>("ShootPartIDs");
+  fExactShoot = gunParams.getParameter<bool>("ExactShoot");
   fRandomShoot = gunParams.getParameter<bool>("RandomShoot");
 
   fEnMax = gunParams.getParameter<double>("EnMax");
@@ -66,7 +66,7 @@ void CloseByFlatDeltaRGunProducer::produce(Event& event, const EventSetup& setup
 
   // determine the number of particles to shoot
   int n = 0;
-  if (fShootPartIDs) {
+  if (fExactShoot) {
     n = (int)fPartIDs.size();
   } else if (fRandomShoot) {
     n = CLHEP::RandFlat::shoot(engine, 1, fNParticles + 1);
@@ -110,7 +110,7 @@ void CloseByFlatDeltaRGunProducer::produce(Event& event, const EventSetup& setup
     HepMC::GenVertex* vtx = new HepMC::GenVertex(HepMC::FourVector(x * cm, y * cm, z * cm, timeOffset * c_light));
 
     // obtain kinematics
-    int id = fShootPartIDs ? fPartIDs[i] : CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size());
+    int id = fExactShoot ? fPartIDs[i] : CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size());
     const HepPDT::ParticleData* pData = fPDGTable->particle(HepPDT::ParticleID(abs(id)));
     double e = CLHEP::RandFlat::shoot(engine, fEnMin, fEnMax);
     double m = pData->mass().value();

--- a/IOMC/ParticleGuns/src/SealModule.cc
+++ b/IOMC/ParticleGuns/src/SealModule.cc
@@ -20,6 +20,7 @@
 #include "IOMC/ParticleGuns/interface/FlatRandomPtAndDxyGunProducer.h"
 #include "IOMC/ParticleGuns/interface/RandomMultiParticlePGunProducer.h"
 #include "IOMC/ParticleGuns/interface/CloseByParticleGunProducer.h"
+#include "IOMC/ParticleGuns/interface/CloseByFlatDeltaRGunProducer.h"
 #include "IOMC/ParticleGuns/interface/RandomXiThetaGunProducer.h"
 
 // particle gun prototypes
@@ -60,5 +61,7 @@ using edm::RandomMultiParticlePGunProducer;
 DEFINE_FWK_MODULE(RandomMultiParticlePGunProducer);
 using edm::CloseByParticleGunProducer;
 DEFINE_FWK_MODULE(CloseByParticleGunProducer);
+using edm::CloseByFlatDeltaRGunProducer;
+DEFINE_FWK_MODULE(CloseByFlatDeltaRGunProducer);
 using edm::RandomXiThetaGunProducer;
 DEFINE_FWK_MODULE(RandomXiThetaGunProducer);


### PR DESCRIPTION
#### PR description:

This PR adds a variant of the CloseBy gun with a configurable ∆R parameter.
The gun is explained [here](https://cernbox.cern.ch/index.php/s/SeoT9zAE0WEzQGL).

Essentially, the first particle is shot in a certain direction and subsequent particles are shot in close proximity, parameterized by ∆R which follows a flat distribution given by the gun parameters ∆R_min and ∆R_max.