### PR TITLE
Rewrite the HGCalRecHitProducer and HGCalRecHitCalibrationAlgorithms to fix various problems

### DIFF
--- a/DataFormats/HGCalDigi/BuildFile.xml
+++ b/DataFormats/HGCalDigi/BuildFile.xml
@@ -1,9 +1,10 @@
-<use name="alpaka"/>
 <use name="eigen"/>
+<use name="rootcore"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/ForwardDetId"/>
 <use name="DataFormats/DetId"/>
-<use name="HeterogeneousCore/AlpakaInterface" source_only="1"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="cuda rocm"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/HGCalDigi/src/alpaka/classes_cuda.h
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_cuda.h
@@ -1,5 +1,4 @@
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/HGCalDigi/interface/HGCalDigiSoA.h"
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalDeviceDigiCollection.h"

--- a/DataFormats/HGCalDigi/src/alpaka/classes_rocm.h
+++ b/DataFormats/HGCalDigi/src/alpaka/classes_rocm.h
@@ -1,5 +1,4 @@
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/HGCalDigi/interface/HGCalDigiSoA.h"
 #include "DataFormats/HGCalDigi/interface/alpaka/HGCalDeviceDigiCollection.h"

--- a/DataFormats/HGCalRecHit/BuildFile.xml
+++ b/DataFormats/HGCalRecHit/BuildFile.xml
@@ -1,9 +1,11 @@
-<use name="alpaka"/>
 <use name="eigen"/>
+<use name="rootcore"/>
 <use name="DataFormats/Common"/>
-<use name="DataFormats/ForwardDetId"/>
+<use name="DataFormats/Portable"/>
 <use name="DataFormats/DetId"/>
-<use name="HeterogeneousCore/AlpakaInterface" source_only="1"/>
+<use name="DataFormats/ForwardDetId"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
+<flags ALPAKA_BACKENDS="cuda rocm"/>
 <export>
   <lib name="1"/>
 </export>

--- a/DataFormats/HGCalRecHit/src/alpaka/classes_cuda.h
+++ b/DataFormats/HGCalRecHit/src/alpaka/classes_cuda.h
@@ -1,5 +1,4 @@
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/HGCalRecHit/interface/HGCalRecHitSoA.h"
 #include "DataFormats/HGCalRecHit/interface/alpaka/HGCalDeviceRecHitCollection.h"

--- a/DataFormats/HGCalRecHit/src/alpaka/classes_rocm.h
+++ b/DataFormats/HGCalRecHit/src/alpaka/classes_rocm.h
@@ -1,5 +1,4 @@
 #include "DataFormats/Common/interface/DeviceProduct.h"
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "DataFormats/Portable/interface/Product.h"
 #include "DataFormats/HGCalRecHit/interface/HGCalRecHitSoA.h"
 #include "DataFormats/HGCalRecHit/interface/alpaka/HGCalDeviceRecHitCollection.h"

--- a/DataFormats/HGCalRecHit/src/classes.h
+++ b/DataFormats/HGCalRecHit/src/classes.h
@@ -1,4 +1,3 @@
-#include <vector>
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/HGCalRecHit/interface/HGCalHostRecHitCollection.h"
 #include "DataFormats/HGCalRecHit/interface/HGCalRecHitSoA.h"

--- a/HeterogeneousCore/AlpakaRecHitTest/plugins/alpaka/AlpakaRecHitTest.cc
+++ b/HeterogeneousCore/AlpakaRecHitTest/plugins/alpaka/AlpakaRecHitTest.cc
@@ -1,4 +1,3 @@
-#include "DataFormats/Portable/interface/Product.h"
 //#include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceCollection.h"
 #include "DataFormats/PortableTestObjects/interface/alpaka/TestDeviceRecHitCollection.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/BuildFile.xml
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/BuildFile.xml
@@ -1,28 +1,8 @@
-<!-- host-only plugins -->
-<!-- <library file="*.cc" name="RecoLocalCaloHGCalRecAlgosPlugins">
-  <use name="alpaka"/>
-  <use name="fmt"/>
-  <use name="DataFormats/PortableTestObjects"/>
-  <use name="FWCore/Framework"/>
-  <use name="FWCore/MessageLogger"/>
-  <use name="FWCore/ParameterSet"/>
-  <use name="FWCore/Utilities"/>
-  <use name="RecoLocalCalo/HGCalRecAlgos"/>
-  <flags EDM_PLUGIN="1"/>
-</library> -->
-
-
-
 <!-- alpaka-based portable plugins -->
 <library file="alpaka/*.cc" name="RecoLocalCaloHGCalRecAlgosPluginsPortable">
   <use name="alpaka"/>
-  <!--
-  The dependency on "DataFormats/PortableTestObjects" automatically expands to include
-  the host-only library (if it exists) and the corresponding Alpaka libraries (if they exist)
-  -->
-  <use name="DataFormats/PortableTestObjects"/>
-  <use name="DataFormats/HGCalRecHit"/>
   <use name="DataFormats/HGCalDigi"/>
+  <use name="DataFormats/HGCalRecHit"/>
   <use name="DataFormats/TestObjects"/>
   <use name="FWCore/Framework"/>
   <use name="FWCore/ParameterSet"/>

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.h
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.h
@@ -21,17 +21,17 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
   class HGCalRecHitCalibrationAlgorithms {
   public:
-    std::unique_ptr<HGCalDeviceRecHitCollection> calibrate(const HGCalHostDigiCollection &digis);
+    std::unique_ptr<HGCalDeviceRecHitCollection> calibrate(Queue& queue, HGCalHostDigiCollection const& digis);
 
     // if converting host digis to device rechits turns out too slow, we should copy host digis to device digis and then
     // convert to device rechits on device
-    // std::unique_ptr<HGCalDeviceRecHitCollection> calibrate(const std::unique_ptr<HGCalDeviceDigiCollection> &digis);
+    // std::unique_ptr<HGCalDeviceRecHitCollection> calibrate(Queue& queue, const std::unique_ptr<HGCalDeviceDigiCollection> &digis);
 
   private:
-    void print(const std::unique_ptr<HGCalDeviceRecHitCollection> &recHits, int max=-1);
-    void print(const HGCalHostDigiCollection &digis, int max=-1);
+    void print(Queue& queue, HGCalDeviceRecHitCollection const& recHits, int max = -1) const;
+    void print(HGCalHostDigiCollection const& digis, int max = -1) const;
   };
 
-} // namespace ALPAKA_ACCELERATOR_NAMESPACE
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
 
-#endif // __HGCalRecHitCalibrationAlgorithms_H__
+#endif  // __HGCalRecHitCalibrationAlgorithms_H__


### PR DESCRIPTION
Drop support for the "old" accelerator framework.
Enable the Alpaka backends in the DataFormats BuildFiles.
Remove unnecessary include.
Clean up unused packages.
Rewrite the HGCalRecHitProducer and HGCalRecHitCalibrationAlgorithms to fix various problems.