### PR TITLE
Speed up Nano further

### DIFF
--- a/DPGAnalysis/HGCalNanoAOD/interface/DigiInfoTableProducer.h
+++ b/DPGAnalysis/HGCalNanoAOD/interface/DigiInfoTableProducer.h
@@ -92,6 +92,7 @@ template <typename T1, typename T2>
     auto siCellInfo = iSetup.getData(siModuleInfoToken_);
 
     ele2geo_=hgcal::mapSiGeoToElectronics(moduleInfo,siCellInfo,false);
+    geo2ele_=hgcal::mapSiGeoToElectronics(moduleInfo,siCellInfo,true);
       
   }
 
@@ -116,21 +117,25 @@ template <typename T1, typename T2>
 
     for (const auto& obj : *objs) {
       if (cut_(obj)) {
-	uint32_t eleID_ = findMatchEleId(obj, ele2geo_);
-	for (const auto& objdigi : *objdigis) {
-	  if ( objdigi.id().raw() == eleID_ ) {
-	    toavals.emplace_back(getTOA(objdigi));
-	    totvals.emplace_back(getTOT(objdigi));
-	    adcvals.emplace_back(getADC(objdigi));
-	    adcm1vals.emplace_back(getADCm1(objdigi));
-	    tctpvals.emplace_back(getTctp(objdigi));
-	    eleIDvals.emplace_back(getElecID(objdigi));
-	    econDIdxvals.emplace_back(getEconDIdx(objdigi));
-	    econDeRxvals.emplace_back(getEconDeRx(objdigi));
-	    halfrocChannelvals.emplace_back(getHalfRocChannel(objdigi));
-	    elecIDisCMvals.emplace_back(getElecIDisCM(objdigi));
-	  }
-	}
+        auto it = geo2ele_.find(obj.detid());
+        if (it != geo2ele_.end()) {
+          auto eleID = it->second;
+          auto it_digi = std::find_if(
+              objdigis->begin(), objdigis->end(), [&eleID](const auto& digi) { return digi.id() == eleID; });
+          if (it_digi != objdigis->end()) {
+            const auto& objdigi = *it_digi;
+            toavals.emplace_back(getTOA(objdigi));
+            totvals.emplace_back(getTOT(objdigi));
+            adcvals.emplace_back(getADC(objdigi));
+            adcm1vals.emplace_back(getADCm1(objdigi));
+            tctpvals.emplace_back(getTctp(objdigi));
+            eleIDvals.emplace_back(getElecID(objdigi));
+            econDIdxvals.emplace_back(getEconDIdx(objdigi));
+            econDeRxvals.emplace_back(getEconDeRx(objdigi));
+            halfrocChannelvals.emplace_back(getHalfRocChannel(objdigi));
+            elecIDisCMvals.emplace_back(getElecIDisCM(objdigi));
+          }
+        }
       }
     }
 
@@ -161,5 +166,6 @@ template <typename T1, typename T2>
   edm::ESGetToken<HGCalCondSerializableSiCellChannelInfo,HGCalCondSerializableSiCellChannelInfoRcd> siModuleInfoToken_;
 
   std::map<uint32_t,uint32_t> ele2geo_;
+  std::map<uint32_t,uint32_t> geo2ele_;
 
 };

--- a/DPGAnalysis/HGCalNanoAOD/test/tb_nano.sh
+++ b/DPGAnalysis/HGCalNanoAOD/test/tb_nano.sh
@@ -7,7 +7,6 @@ fileout=$2
 jobtag=$3
 [[ -z ${jobtag} ]] && jobtag=""
 
-
 cmsDriver.py NANO \
     -s USER:DPGAnalysis/HGCalNanoAOD/hgcRecHits_cff.hgctbTask \
     --datatier NANOAOD \
@@ -21,7 +20,7 @@ cmsDriver.py NANO \
     --era Phase2C17I13M9 \
     --python_filename nanocmsdriver_${jobtag}_cfg.py \
     --customise DPGAnalysis/HGCalTools/tb2023_cfi.configTBConditions \
-    --customise_commands "process.MessageLogger.cerr.FwkReport.reportEvery = 50000 " \
+    --customise_commands "process.NANOAODoutput.compressionAlgorithm = 'ZSTD'\nprocess.NANOAODoutput.compressionLevel = 5\nprocess.MessageLogger.cerr.FwkReport.reportEvery = 50000\nprocess.options.wantSummary = True\n" \
     --no_exec
 
 cmsRun -j FrameworkJobReport_${jobtag}_NANO.xml nanocmsdriver_${jobtag}_cfg.py


### PR DESCRIPTION
~5x speedup with 4 threads:

[Before]
```
TimeReport ---------- Module Summary ---[Real sec]----
TimeReport  per event     per exec    per visit  Name
TimeReport   0.000000     0.000000     0.000000  MEtoEDMConverter
TimeReport   0.001581     0.001581     0.001581  NANOAODoutput
TimeReport   0.000002     0.000002     0.000002  NANOAODoutput_step
TimeReport   0.000001     0.000001     0.000001  TriggerResults
TimeReport   0.000001     0.000001     0.000001  endjob_step
TimeReport   0.000472     0.000472     0.000472  hgcDigiTable
TimeReport   0.000140     0.000140     0.000140  hgctbRecHitsPositionTable
TimeReport   0.000194     0.000194     0.000194  hgctbRecHitsTable
TimeReport   0.000005     0.000005     0.000005  tbMetaDataTable
TimeReport   0.000002     0.000002     0.000002  user_step
TimeReport  per event     per exec    per visit  Name
```

[After]
```
TimeReport ---------- Module Summary ---[Real sec]----
TimeReport  per event     per exec    per visit  Name
TimeReport   0.000000     0.000000     0.000000  MEtoEDMConverter
TimeReport   0.000140     0.000140     0.000140  NANOAODoutput
TimeReport   0.000002     0.000002     0.000002  NANOAODoutput_step
TimeReport   0.000001     0.000001     0.000001  TriggerResults
TimeReport   0.000001     0.000001     0.000001  endjob_step
TimeReport   0.000057     0.000057     0.000057  hgcDigiTable
TimeReport   0.000142     0.000142     0.000142  hgctbRecHitsPositionTable
TimeReport   0.000197     0.000197     0.000197  hgctbRecHitsTable
TimeReport   0.000005     0.000005     0.000005  tbMetaDataTable
TimeReport   0.000002     0.000002     0.000002  user_step
TimeReport  per event     per exec    per visit  Name
```

The output file size is increased by ~2x due to the change from `LZMA:9` to `ZSTD:5`.

@pfs @mariadalfonso
