### PR TITLE
[Calibration] Update format of calibration parameters

### DIFF
--- a/DPGAnalysis/HGCalTools/python/tb2023_cfi.py
+++ b/DPGAnalysis/HGCalTools/python/tb2023_cfi.py
@@ -24,7 +24,7 @@ def configTBConditions(process,key='default'):
     process.hgCalSiModuleInfoESSource.filename = 'Geometry/HGCalMapping/data/WaferCellMapTraces.txt'
 
     pedestals={
-        'default':'/eos/cms/store/group/dpg_hgcal/comm_hgcal/ykao/calibration_parameters.txt',
+        'default':'/eos/cms/store/group/dpg_hgcal/comm_hgcal/ykao/calibration_parameters_v2.txt',
     }
     if hasattr(process,'hgCalPedestalsESSource'):
         process.hgCalPedestalsESSource.filename = pedestals[key]

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalCalibrationParameterSoA.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalCalibrationParameterSoA.h
@@ -18,7 +18,8 @@ namespace hgcalrechit {
                       SOA_COLUMN(float, pedestal),
                       SOA_COLUMN(float, CM_slope),
                       SOA_COLUMN(float, CM_offset),
-                      SOA_COLUMN(float, BXm1_kappa)
+                      SOA_COLUMN(float, BXm1_slope),
+                      SOA_COLUMN(float, BXm1_offset)
   )
   using HGCalCalibParamSoA = HGCalCalibrationParameterSoALayout<>;
   

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
@@ -67,7 +67,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       auto const& config_calib_param = calib.config();
       for (auto index : elements_with_stride(acc, rechits.metadata().size())) {
         uint32_t idx = config_calib_param.denseMap(digis[index].electronicsId());
-        float ADCmValue = calib[idx].BXm1_kappa() * digis[index].adcm1(); // placeholder
+        float ADCmValue = calib[idx].BXm1_slope() * digis[index].adcm1() + calib[idx].BXm1_offset(); // placeholder
         rechits[index].adc() -= ADCmValue;
       }
     }
@@ -100,7 +100,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     LogDebug("HGCalRecHitCalibrationAlgorithms") << "\n\nINFO -- copying the digis to the device\n\n" << std::endl;
     HGCalDigiDeviceCollection device_digis(host_digis.view().metadata().size(), queue);
     alpaka::memcpy(queue, device_digis.buffer(), host_digis.const_buffer());
-    
+
     LogDebug("HGCalRecHitCalibrationAlgorithms") << "\n\nINFO -- allocating rechits buffer and initiating values" << std::endl;
     auto device_recHits = std::make_unique<HGCalRecHitDeviceCollection>(device_digis.view().metadata().size(), queue);
     alpaka::exec<Acc1D>(queue, grid, HGCalRecHitCalibrationKernel_digisToRecHits{}, device_digis.view(), device_recHits->view());

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationESProducer.cc
@@ -73,22 +73,23 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
       std::ifstream file(fip.fullPath());
       std::string line;
       uint32_t id;
-      float ped,cm_slope,cm_off,kappa_bxm1;
+      float ped,noise,cm_slope,cm_offset,bxm1_slope,bxm1_offset;
       while(std::getline(file, line)) {
         if(line.find("Channel")!=std::string::npos || line.find("#")!=std::string::npos) continue;
 
         std::istringstream stream(line);
-        stream >> id >> ped >> cm_slope >> cm_off >> kappa_bxm1;
+        stream >> std::hex >> id >> std::dec >> ped >> noise >> cm_slope >> cm_offset >> bxm1_slope >> bxm1_offset;
 
         //reduce to half-point float and fill the pedestals of this channel
         uint32_t idx = ccp.denseMap(id); // convert electronicsId to idx from denseMap 
 
         // Comment: if planning to use MiniFloatConverter::float32to16(), a host function,
         // one needs to think how to perform MiniFloatConverter::float16to32() in kernels running on GPU (HGCalRecHitCalibrationAlgorithms.dev.cc)
-        product.view()[idx].pedestal()   = ped;
-        product.view()[idx].CM_slope()   = cm_slope;
-        product.view()[idx].CM_offset()  = cm_off;
-        product.view()[idx].BXm1_kappa() = kappa_bxm1;
+        product.view()[idx].pedestal()    = ped;
+        product.view()[idx].CM_slope()    = cm_slope;
+        product.view()[idx].CM_offset()   = cm_offset;
+        product.view()[idx].BXm1_slope()  = bxm1_slope;
+        product.view()[idx].BXm1_offset() = bxm1_offset;
       }
 
       return product;

--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitProducer.cc
@@ -106,11 +106,12 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     if (cfgWatcher_.check(iSetup)){
       for(int i=0; i<deviceCalibrationParameterProvider.view().metadata().size(); i++) {
           LogDebug("HGCalCalibrationParamter")
-                    << "idx = "        << i << ", "
-                    << "pedestal = "   << deviceCalibrationParameterProvider.view()[i].pedestal()   << ", "
-                    << "CM_slope = "   << deviceCalibrationParameterProvider.view()[i].CM_slope()   << ", "
-                    << "CM_offset = "  << deviceCalibrationParameterProvider.view()[i].CM_offset()  << ", "
-                    << "BXm1_kappa = " << deviceCalibrationParameterProvider.view()[i].BXm1_kappa() << std::endl;
+                    << "idx = "         << i << ", "
+                    << "pedestal = "    << deviceCalibrationParameterProvider.view()[i].pedestal()    << ", "
+                    << "CM_slope = "    << deviceCalibrationParameterProvider.view()[i].CM_slope()    << ", "
+                    << "CM_offset = "   << deviceCalibrationParameterProvider.view()[i].CM_offset()   << ", "
+                    << "BXm1_slope = "  << deviceCalibrationParameterProvider.view()[i].BXm1_slope()  << ", "
+                    << "BXm1_offset = " << deviceCalibrationParameterProvider.view()[i].BXm1_offset() << std::endl;
       }
     }
 


### PR DESCRIPTION
## PR description:

Updated features
- Update the format of the default text file for calibration parameters
- Remove BXm1_kappa
- Add BXm1_slope and BXm1_offset
- Decode electronics Id using `std::hex`

## PR validation:
Test on lxplus8. Values of parameters passed to the calibration kernel are consistent with the input file, `/eos/cms/store/group/dpg_hgcal/comm_hgcal/ykao/calibration_parameters_v2.txt`.

Log messages with printed values can be found here
https://ykao.web.cern.ch/ykao/raw_data_handling/hgcal_alpaka/log_calib_validate_20230802.txt

## Caveat:
There exists a mismatch: electronics Id evaluated in [DQM/HGCal/plugins/HGCalDigisClientHarvester.cc#L233](https://github.com/CMS-HGCAL/cmssw/blob/hgcal-condformat-HGCalNANO-13_2_0_pre2/DQM/HGCal/plugins/HGCalDigisClientHarvester.cc#L233) is different from electronics Ids of current digis collection in [DQM/HGCal/plugins/HGCalDigisClient.cc#L127](https://github.com/CMS-HGCAL/cmssw/blob/hgcal-condformat-HGCalNANO-13_2_0_pre2/DQM/HGCal/plugins/HGCalDigisClient.cc#L127). A piece of log messages with values printed out are shown below

```
[DEBUG] DQM/HGCal/plugins/HGCalDigisClient.cc ...
eleid.raw() = 0, Electronics Id = 0x0, adc = 379, adcm1 = 0, tot = 0, halfrocChannel = 0, channel = 0, CM = 0
eleid.raw() = 1, Electronics Id = 0x1, adc = 88, adcm1 = 0, tot = 0, halfrocChannel = 1, channel = 1, CM = 0
eleid.raw() = 2, Electronics Id = 0x2, adc = 90, adcm1 = 0, tot = 0, halfrocChannel = 2, channel = 2, CM = 0
eleid.raw() = 3, Electronics Id = 0x3, adc = 73, adcm1 = 0, tot = 0, halfrocChannel = 3, channel = 3, CM = 0
eleid.raw() = 4, Electronics Id = 0x4, adc = 106, adcm1 = 0, tot = 0, halfrocChannel = 4, channel = 4, CM = 0
eleid.raw() = 5, Electronics Id = 0x5, adc = 116, adcm1 = 0, tot = 0, halfrocChannel = 5, channel = 5, CM = 0
...
[DEBUG] DQM/HGCal/plugins/HGCalDigisClientHarvester.cc ...
eleid.raw() = 344064, zside = 0, slink = 1, captureblock = 5, econd = 0, erx = 0, seq = 0, 
eleid.raw() = 344065, zside = 0, slink = 1, captureblock = 5, econd = 0, erx = 0, seq = 1, 
eleid.raw() = 344066, zside = 0, slink = 1, captureblock = 5, econd = 0, erx = 0, seq = 2, 
eleid.raw() = 344067, zside = 0, slink = 1, captureblock = 5, econd = 0, erx = 0, seq = 3, 
eleid.raw() = 344068, zside = 0, slink = 1, captureblock = 5, econd = 0, erx = 0, seq = 4,
...
```

where the first electronics id printed from the harvester is 344064 = 2^18 + 2^16 + 2^14, coming from `slink=1` and `captureblock=5`.

The mismatch will lead to a consequence that no proper calibration parameters will be used when calibrating digis using parameters exported from `DQM/HGCal/plugins/HGCalDigisClientHarvester.cc`.

Full log can be found at this link
https://ykao.web.cern.ch/ykao/raw_data_handling/hgcal_alpaka/log_dqm_eleId_mismatch_20230802.txt