### PR TITLE
Single module data parser fix

### DIFF
--- a/EventFilter/HGCalRawToDigi/interface/HGCalModuleTreeReader.h
+++ b/EventFilter/HGCalRawToDigi/interface/HGCalModuleTreeReader.h
@@ -35,9 +35,10 @@ namespace hgcal::econd {
     HGCalTestSystemMetaData nextMetaData() override;
     
   private:
-    ECONDInputColl data_;
-    ECONDInputColl::const_iterator it_data_;
-    std::map<hgcal::econd::EventId,HGCalTestSystemMetaData> metadata_;
+    
+    uint32_t iEvent_,totalEvents_;    
+    std::map< ERxId_t, std::vector<std::tuple<EventId, ERxData>> > data_;
+    std::map< ERxId_t, std::vector<std::tuple<EventId, HGCalTestSystemMetaData>> > metadata_;    
   };
 
 }  // namespace hgcal::econd


### PR DESCRIPTION
Modify tree reader to do the proper thing: map events by eRx and fil a sequential vector. 
Add asserts for the number of events read from the file.
Add a simple check for the synchronicity of the event counters.
For the test files used (LD, LD3, LD4, HD) only the HD shows ~280/10000 events where the counters are out of sync so it will be interesting to see what happens with the ECON-D
