### PR TITLE
Rework handling of ECON-D status throughout the chain 

### DIFF
--- a/DPGAnalysis/HGCalNanoAOD/python/hgcRecHits_cff.py
+++ b/DPGAnalysis/HGCalNanoAOD/python/hgcRecHits_cff.py
@@ -96,7 +96,9 @@ unpackerFlagsTable = cms.EDProducer("SimpleHGCalUnpackerFlagsTableProducer",
                                     variables = cms.PSet(
                                         eleid = Var('eleid', 'uint', precision=-1, doc='electronics id'),
                                         flags = Var('flags', 'uint', precision=-1, doc='HGCalFlaggedECONDInfo flags word'),
-                                        iword = Var('iword', 'uint', precision=-1, doc='faulty word when unpacking'),
+                                        cbflags = Var('cbflags', 'uint', precision=-1, doc='Capture block flags for this ECON-D'),
+                                        payload = Var('payload', 'uint', precision=-1, doc='ECON-D payload in the header'),
+                                        iword = Var('iword', 'uint', precision=-1, doc='ECON-D 32b word position when unpacking FED data'),
                                     )
 )
 

--- a/DQM/HGCal/plugins/HGCalDigisClient.cc
+++ b/DQM/HGCal/plugins/HGCalDigisClient.cc
@@ -250,6 +250,18 @@ void HGCalDigisClient::analyze(const edm::Event& iEvent, const edm::EventSetup& 
       for (size_t k = 1; k <= tosum.size(); k++)
         p_sums[geomKey]->setBinContent(
             globalChannelId, k, p_sums[geomKey]->getBinContent(globalChannelId, k) + tosum[k - 1]);
+      
+      //also add the TOA/TOT sums
+      if(toa>0){
+        p_sums[geomKey]->setBinContent( globalChannelId, 13, p_sums[geomKey]->getBinContent(globalChannelId, 13) + 1);
+        p_sums[geomKey]->setBinContent( globalChannelId, 14, p_sums[geomKey]->getBinContent(globalChannelId, 14) + double(toa));
+        p_sums[geomKey]->setBinContent( globalChannelId, 15, p_sums[geomKey]->getBinContent(globalChannelId, 15) + double(toa*toa));
+      }
+      if(tot>0){
+        p_sums[geomKey]->setBinContent( globalChannelId, 16, p_sums[geomKey]->getBinContent(globalChannelId, 16) + 1);
+        p_sums[geomKey]->setBinContent( globalChannelId, 17, p_sums[geomKey]->getBinContent(globalChannelId, 17) + double(tot));
+        p_sums[geomKey]->setBinContent( globalChannelId, 18, p_sums[geomKey]->getBinContent(globalChannelId, 18) + double(tot*tot));
+      }
 
       // For the last itetration, get the information from the CM and add it in the ADC row for the CM channels
       // so that the hex_pedestal maps will be filled for the CM channels in the HGCalDigisClientHarvester.cc
@@ -373,7 +385,7 @@ void HGCalDigisClient::bookHistograms(DQMStore::IBooker& ibook, edm::Run const& 
         "tot_vs_trigtime_" + tag, ";trigger phase; TOT of channel with max <TOT>", 200, 0, 200, 100, 0, 4096);
     p_toavstrigtime[k] = ibook.book2D(
         "toa_vs_trigtime_" + tag, ";trigger phase; TOA of channel with max <ADC-ADC_{-1}>", 200, 0, 200, 100, 0, 1024);
-    p_sums[k] = ibook.book2D("sums_" + tag, ";Channel;", nch, 0, nch, 12, 0, 12);
+    p_sums[k] = ibook.book2D("sums_" + tag, ";Channel;", nch, 0, nch, 18, 0, 18);
     p_sums[k]->setBinLabel(1, "N", 2);
     p_sums[k]->setBinLabel(2, "#sum ADC", 2);
     p_sums[k]->setBinLabel(3, "#sum ADC^{2}", 2);
@@ -383,9 +395,16 @@ void HGCalDigisClient::bookHistograms(DQMStore::IBooker& ibook, edm::Run const& 
     p_sums[k]->setBinLabel(7, "#sum ADC_{-1}", 2);
     p_sums[k]->setBinLabel(8, "#sum ADC_{-1}^{2}", 2);
     p_sums[k]->setBinLabel(9, "#sum ADC*ADC_{-1}", 2);
-    p_sums[k]->setBinLabel(10, "#sum TDC", 2);
-    p_sums[k]->setBinLabel(11, "#sum TDC^{2}", 2);
-    p_sums[k]->setBinLabel(12, "#sum ADC*TDC", 2);
+    p_sums[k]->setBinLabel(10, "#sum N(TDC)", 2);
+    p_sums[k]->setBinLabel(11, "#sum N(TDC)^{2}", 2);
+    p_sums[k]->setBinLabel(12, "#sum ADC*N(TDC)", 2);
+    p_sums[k]->setBinLabel(13, "N(TOA)", 2);
+    p_sums[k]->setBinLabel(14, "#sum TOA", 2);
+    p_sums[k]->setBinLabel(15, "#sum TOA^{2}", 2);
+    p_sums[k]->setBinLabel(16, "N(TOT)", 2);
+    p_sums[k]->setBinLabel(17, "#sum TOT", 2);
+    p_sums[k]->setBinLabel(18, "#sum TOT^{2}", 2);
+
     p_maxadc[k] = ibook.book1D("maxadc_" + tag, ";max ADC; Counts", 100, 0, 1024);
     p_adc[k] = ibook.bookProfile("p_adc_" + tag, ";Channel; ADC", nch, 0, nch, 100, 0, 1024);
     p_adc[k]->setOption("s");  //save standard deviation instead of error mean for noise estimate

--- a/DataFormats/HGCalDigi/interface/HGCalFlaggedECONDInfo.h
+++ b/DataFormats/HGCalDigi/interface/HGCalFlaggedECONDInfo.h
@@ -7,6 +7,20 @@ class HGCalFlaggedECONDInfo
 {
  public:
 
+  /**
+     @short flags in the capture block header pertaining an ECON-D
+   */
+  enum CBFlagTypes { PAYLOADTOOLARGE=1,
+		     CRCERROR=2,
+		     EVENTIDMISMATCH=3,
+		     FSMTIMEOUT=4,
+		     BCorORBITIDMISMATCH=5,
+		     MAINBUFFEROVERFLOW=6,
+		     INACTIVEINPUT=7};
+
+  /**
+     @short flags in the ECON-D header
+   */
   enum FlagTypes { CBSTATUS=1,
                    HTBITS=2,
                    EBOBITS=4,
@@ -17,12 +31,15 @@ class HGCalFlaggedECONDInfo
                    PAYLOADMISMATCHES=128,
                    UNEXPECTEDTRUNCATED=256};
   
-  HGCalFlaggedECONDInfo() : HGCalFlaggedECONDInfo(0,0,0) {}
-  HGCalFlaggedECONDInfo(uint32_t loc, uint32_t flagbits, uint32_t id)
-    : iword(loc), flags(flagbits), eleid(id) {}
+  HGCalFlaggedECONDInfo() : HGCalFlaggedECONDInfo(0,0,0,0,0) {}
+  HGCalFlaggedECONDInfo(uint32_t loc, uint32_t cbflagbits, uint32_t flagbits, uint32_t id, uint32_t pl)
+    : iword(loc), cbflags(cbflagbits), flags(flagbits), eleid(id), payload(pl) {}
   HGCalFlaggedECONDInfo(const HGCalFlaggedECONDInfo &t)
-    : HGCalFlaggedECONDInfo(t.iword,t.flags,t.eleid) {}
-  
+    : HGCalFlaggedECONDInfo(t.iword,t.cbflags,t.flags,t.eleid,t.payload) {}
+
+  void setPayload(uint32_t v) { payload=v; }
+  void addFlag(FlagTypes f) { flags += f; } 
+  void addToFlag(uint32_t v) { flags += v; } 
   bool cbFlag() { return flags & 0x1; };
   bool htFlag() { return (flags>>1) & 0x1; };
   bool eboFlag() { return (flags>>2) & 0x1; };
@@ -33,7 +50,7 @@ class HGCalFlaggedECONDInfo
   bool payloadMismatches() { return (flags>>7) & 0x1; };
   bool unexpectedTruncated() { return (flags>>8) & 0x1; };
     
-  uint32_t iword,flags,eleid;
+  uint32_t iword,cbflags,flags,eleid,payload;
 };
 
 typedef std::vector<HGCalFlaggedECONDInfo> HGCalFlaggedECONDInfoCollection;

--- a/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
+++ b/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
@@ -89,12 +89,16 @@ public:
   void parseSLink(const std::vector<uint32_t>& inputArray,
                   const std::function<uint16_t(uint16_t sLink, uint8_t captureBlock, uint8_t econd)>& enabledERXMapping,
                   const std::function<uint16_t(uint16_t fedid)>& fed2slink);
+
+  /// we should think of removing this method
   /// parse input in capture block format
   /// \param[in] inputArray input as 32-bits words vector.
   /// \param[in] enabledERXMapping map from capture block indices to enabled eRx in this ECON-D
   void parseCaptureBlock(
       const std::vector<uint32_t>& inputArray,
       const std::function<uint16_t(uint16_t sLink, uint8_t captureBlock, uint8_t econd)>& enabledERXMapping);
+
+  /// we should think of removing this method
   /// parse input in ECON-D format
   /// \param[in] inputArray input as 32-bits words vector.
   /// \param[in] enabledERXMapping map from ECON-D indices to enabled eRx in this ECON-D
@@ -107,8 +111,6 @@ public:
   const std::vector<uint16_t>& commonModeSum() const{ return commonModeSum_; }
   /// \return vector of HGCROCChannelDataFrame<ElecID>(ID, value) for common modes
   const std::vector<HGCROCChannelDataFrame<HGCalElectronicsId> >& commonModeData() const { return commonModeData_; }
-
-
   /// \return vector of flagged ECOND information
   const HGCalFlaggedECONDInfoCollection& flaggedECOND() const { return flaggedECOND_; }
 

--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -156,15 +156,12 @@ void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
                               }
                             });
     } catch(cms::Exception &e) {
-      std::cout << "An exeption was caught while decoding raw data for FED " << (uint32_t)fed_id << std::endl;
+      std::cout << "An exeption was caught while decoding raw data for FED "  << std::dec << (uint32_t)fed_id << std::endl;
       std::cout << e.what() << std::endl;
       std::cout << "Event is: " << std::endl;
-      std::cout << "Total size (32b words) " << data_32bit.size() << std::endl;
-      for(size_t i=0; i<10; i++)
-        std::cout << std::hex << "0x" << std::setfill('0') << data_32bit[i] << std::endl;
-      std::cout << "..." << std::endl;
-      for(size_t i=data_32bit.size()-4; i<data_32bit.size(); i++)
-        std::cout << std::hex << "0x" << std::setfill('0') << data_32bit[i] << std::endl;
+      std::cout << "Total size (32b words) " << std::dec << data_32bit.size() << std::endl;
+      for(size_t i=0; i<data_32bit.size(); i++)
+        std::cout << std::dec << i << " | "  << std::hex << "0x" << std::setfill('0') << data_32bit[i] << std::endl;
     }
 
     auto channeldata = unpacker_->channelData();


### PR DESCRIPTION
Adding a finer granularity monitoring of ECON-D status and simplifying the most the handling of their status in the capture block header

This PR should address #64, #65, #66, #67 