### PR TITLE
add missing module locator + fix to unpacker resize

### DIFF
--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -357,10 +357,10 @@ void HGCalUnpacker::parseSLink(
     iword += 4;  // length of the S-Link trailer (128 bits)
   }
 
-  //in case an ECON was suppressed this will set the array to 0 ...
-  //channelData_.resize(channelDataSize_);
-  //commonModeSum_.resize(channelDataSize_);
-  //commonModeData_.resize(commonModeDataSize_);
+  //this needs to be resized to the final size
+  channelData_.resize(channelDataSize_);
+  commonModeSum_.resize(channelDataSize_);
+  commonModeData_.resize(commonModeDataSize_);
   return;
 }
 

--- a/Geometry/HGCalMapping/data/modulelocator_tb_MHDF56.txt
+++ b/Geometry/HGCalMapping/data/modulelocator_tb_MHDF56.txt
@@ -1,0 +1,2 @@
+plane   u   v   isSiPM  HDorLD  itype   idx     captureblock    slink   captureblockidx     fedid zside
+    1   1   1        0       1      0     0                0        0                 0         0    -1


### PR DESCRIPTION
Missing module locator file for single module runs
There was a misunderstanding in the resize of the vectors after unpacking leading to a duplication of size (filled with 0's) in runs with two modules in different links.