### PR TITLE
Bug fix: TcTp > 1 for TOT

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/plugins/alpaka/HGCalRecHitCalibrationAlgorithms.dev.cc
@@ -23,7 +23,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     ALPAKA_FN_ACC void operator()(TAcc const& acc, HGCalDigiDeviceCollection::View digis, HGCalRecHitDeviceCollection::View recHits) const {
       auto ToA_to_time = [&](uint32_t ToA) { return float(ToA)*0.024414062; }; // LSB=25 ns / 2^10b
-      auto ADC_to_float = [&](uint32_t ADC, uint32_t TOT, uint8_t tctp) { return float(tctp>0 ? TOT : ADC); };
+      auto ADC_to_float = [&](uint32_t ADC, uint32_t TOT, uint8_t tctp) { return float(tctp>1 ? TOT : ADC); };
       
       // dummy digis -> rechits conversion (to be replaced by the actual formula)
       for (auto index : elements_with_stride(acc, digis.metadata().size())) {
@@ -54,7 +54,7 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
     ALPAKA_FN_ACC void operator()(TAcc const& acc, HGCalDigiDeviceCollection::View digis, HGCalRecHitDeviceCollection::View recHits, HGCalConfigParamDeviceCollection::ConstView config) const {
       auto const& config_param = config.config();
       auto ADC_to_charge = [&](float energy, uint8_t tctp, uint8_t gain) {
-        return tctp>0 ? energy*1.953125 : energy*gain/0.078125; // fC
+        return tctp>1 ? energy*1.953125 : energy*gain*0.078125; // fC
         //                TOT / 2^12 * 8000 fC = TOT * 1.953125 fC
         // ( ADC - pedestal ) / 2^10 *   80 fC = ( ADC - pedestal ) * 0.078125 fC
       };


### PR DESCRIPTION
As discussed yesterday in the [CMG HGCal Chat](https://indico.cern.ch/event/1333054/) with @asteencern, @adavidzh, @pfs: TcTp has a 2-bit value, and TOT should be used for TcTp > 1.

From p. 33 in the [HGCROC3 spec working document](https://edms.cern.ch/ui/file/2324379/1/HGCROC3_Spec_Working_Document_v2.0.pdf):
> Tc and Tp Interpretation:
> * 0b00 : The TOT is not in operation (not busy), normal behaviour with ADC data (TOT filled with 0)
> * 0b01 : The TOT is busy (integration or undershoot), Tp highlights the fact that provided ADC
correspond to saturation (during integration) or undershoot (TOT filled with 0)
> * 0b10 : should not appear => we only output value when TOT is busy
> * 0b11 : The TOT value is output, normal behaviour with TOT data (ADC value is between saturation
and undershoot)

While this PR is open, @hqucms, do you know if the compiler should already optimize this? (See https://en.wikipedia.org/wiki/Constant_folding):
```
       return tctp>1 ? energy*(1<<12)*8000 : energy*gain/(1<<10)*80; // fC
        //                TOT / 2^12 * 8000 fC = TOT * 1.953125 fC
        // ( ADC - pedestal ) / 2^10 *   80 fC = ( ADC - pedestal ) * 0.078125 fC
```

Also for the record: @adavidzh proposed to look into branchless programming for optimizing `cond ? branch1 : branch2`.