### PR TITLE
Dense Index Info SOA

### DIFF
--- a/CondFormats/DataRecord/interface/HGCalDenseIndexInfoRcd.h
+++ b/CondFormats/DataRecord/interface/HGCalDenseIndexInfoRcd.h
@@ -1,0 +1,29 @@
+#ifndef CondFormats_HGCalDenseIndexInfoRcd_h
+#define CondFormats_HGCalDenseIndexInfoRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HGCalDenseIndexInfoRcd
+//
+/**\class HGCalDenseIndexInfoRcd HGCalDenseIndexInfoRcd.h CondFormats/DataRecord/interface/HGCalDenseIndexInfoRcd.h
+ *
+ * Description:
+ *   This record is used join information from the geometry and logical mapping
+ *   This record depends on the HGCalElectronicsMappingRcd and CaloGeometryRecord
+ *
+ */
+//
+// Author:      Pedro Da Silva, Izaak Neutelings
+// Created:     Mon, 29 May 2023 09:13:07 GMT
+//
+
+#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+#include "FWCore/Utilities/interface/mplVector.h"
+#include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+
+class HGCalDenseIndexInfoRcd
+  : public edm::eventsetup::DependentRecordImplementation<HGCalDenseIndexInfoRcd,
+                                                          edm::mpl::Vector<HGCalElectronicsMappingRcd,CaloGeometryRecord> > {};
+
+#endif

--- a/CondFormats/DataRecord/src/HGCalDenseIndexInfoRcd.cc
+++ b/CondFormats/DataRecord/src/HGCalDenseIndexInfoRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HGCalDenseIndexInfoRcd
+//
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Pedro Da Silva, Izaak Neutelings
+// Created:     Mon, 29 May 2023 09:13:07 GMT
+
+#include "CondFormats/DataRecord/interface/HGCalDenseIndexInfoRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(HGCalDenseIndexInfoRcd);

--- a/CondFormats/HGCalObjects/interface/HGCalMappingParameterHost.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingParameterHost.h
@@ -12,6 +12,9 @@ namespace hgcal {
   // SoA with channel-level cell mapping parameters in host memory for both Si and SiPM channels:
   using HGCalMappingCellParamHost = PortableHostCollection<HGCalMappingCellParamSoA>;
 
+  //SoA with detailed indices corresponding to the dense index in use
+  using HGCalDenseIndexInfoHost = PortableHostCollection<HGCalDenseIndexInfoSoA>;
+
 }  // namespace hgcal
 
 #endif  // CondFormats_HGCalObjects_interface_HGCalMappingParameterHost_h

--- a/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
+++ b/CondFormats/HGCalObjects/interface/HGCalMappingParameterSoA.h
@@ -51,6 +51,20 @@ namespace hgcal {
                       SOA_COLUMN(uint32_t, detid))
   using HGCalMappingCellParamSoA = HGCalMappingCellParamSoALayout<>;
 
+  // Generate structure of channel-level arrays (SoA) layout with module mapping information
+  GENERATE_SOA_LAYOUT(HGCalDenseIndexInfoSoALayout,
+                      SOA_COLUMN(uint32_t, fedId),
+                      SOA_COLUMN(uint32_t, fedReadoutSeq),
+                      SOA_COLUMN(uint32_t, detid),
+                      SOA_COLUMN(uint32_t, eleid),
+                      SOA_COLUMN(uint32_t, modInfoIdx),
+                      SOA_COLUMN(uint32_t, cellInfoIdx),
+                      SOA_COLUMN(uint32_t, chNumber),
+                      SOA_COLUMN(float, x),
+                      SOA_COLUMN(float, y),
+                      SOA_COLUMN(float, z))
+  using HGCalDenseIndexInfoSoA = HGCalDenseIndexInfoSoALayout<>;
+
 }  // namespace hgcal
 
 #endif  // CondFormats_HGCalObjects_interface_HGCalMappingParameterSoA_h

--- a/CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDevice.h
+++ b/CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDevice.h
@@ -12,9 +12,11 @@ namespace ALPAKA_ACCELERATOR_NAMESPACE {
 
     using HGCalMappingModuleParamDevice = PortableCollection<::hgcal::HGCalMappingModuleParamSoA>;
     using HGCalMappingCellParamDevice = PortableCollection<::hgcal::HGCalMappingCellParamSoA>;
+    using HGCalDenseIndexInfoDevice = PortableCollection<::hgcal::HGCalDenseIndexInfoSoA>;
 
     using HGCalMappingModuleParamHost = ::hgcal::HGCalMappingModuleParamHost;
     using HGCalMappingCellParamHost = ::hgcal::HGCalMappingCellParamHost;
+    using HGCalDenseIndexInfoHost = ::hgcal::HGCalDenseIndexInfoHost;
 
   }  // namespace hgcal
 

--- a/CondFormats/HGCalObjects/src/HGCalMappingParameterHost.cc
+++ b/CondFormats/HGCalObjects/src/HGCalMappingParameterHost.cc
@@ -3,3 +3,4 @@
 
 TYPELOOKUP_DATA_REG(hgcal::HGCalMappingModuleParamHost);
 TYPELOOKUP_DATA_REG(hgcal::HGCalMappingCellParamHost);
+TYPELOOKUP_DATA_REG(hgcal::HGCalDenseIndexInfoHost);

--- a/CondFormats/HGCalObjects/src/alpaka/HGCalMappingParameterDevice.cc
+++ b/CondFormats/HGCalObjects/src/alpaka/HGCalMappingParameterDevice.cc
@@ -3,3 +3,4 @@
 
 TYPELOOKUP_ALPAKA_DATA_REG(hgcal::HGCalMappingModuleParamDevice);
 TYPELOOKUP_ALPAKA_DATA_REG(hgcal::HGCalMappingCellParamDevice);
+TYPELOOKUP_ALPAKA_DATA_REG(hgcal::HGCalDenseIndexInfoDevice);

--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -103,7 +103,7 @@ void HGCalRawToDigi::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetu
 }
 
 void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  hgcaldigi::HGCalDigiHost digis(cellIndexer_.maxDenseIndex(), cms::alpakatools::host());
+  hgcaldigi::HGCalDigiHost digis(moduleIndexer_.getMaxDataSize(), cms::alpakatools::host());
   hgcaldigi::HGCalECONDInfoHost econdInfo(moduleIndexer_.getMaxModuleSize(), cms::alpakatools::host());
   // std::cout << "Created DIGIs SOA with " << digis.view().metadata().size() << " entries" << std::endl;
 

--- a/Geometry/HGCalMapping/plugins/BuildFile.xml
+++ b/Geometry/HGCalMapping/plugins/BuildFile.xml
@@ -3,6 +3,9 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="Geometry/HGCalMapping"/>
+<use name="Geometry/Records"/>
+<use name="Geometry/CaloGeometry"/>
+<use name="Geometry/HGCalGeometry"/>
 <use name="FWCore/Utilities"/>
 
 <!-- indexer plugin -->

--- a/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexInfoESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/alpaka/HGCalDenseIndexInfoESProducer.cc
@@ -1,0 +1,161 @@
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ESProducer.h"
+#include "HeterogeneousCore/AlpakaCore/interface/alpaka/ModuleFactory.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/config.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/memory.h"
+#include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
+#include "CondFormats/DataRecord/interface/HGCalDenseIndexInfoRcd.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHost.h"
+#include "CondFormats/HGCalObjects/interface/alpaka/HGCalMappingParameterDevice.h"
+#include "DataFormats/HGCalDigi/interface/HGCalElectronicsId.h"
+#include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
+#include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
+#include "Geometry/HGCalMapping/interface/HGCalMappingTools.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
+
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+namespace ALPAKA_ACCELERATOR_NAMESPACE {
+
+  namespace hgcal {
+
+    class HGCalDenseIndexInfoESProducer : public ESProducer {
+    public:
+      //
+      HGCalDenseIndexInfoESProducer(const edm::ParameterSet& iConfig) : ESProducer(iConfig) {
+        auto cc = setWhatProduced(this);
+        moduleIndexTkn_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("moduleindexer"));
+        cellIndexTkn_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("cellindexer"));
+        moduleInfoTkn_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("moduleinfo"));
+        cellInfoTkn_ = cc.consumes(iConfig.getParameter<edm::ESInputTag>("cellinfo"));
+        caloGeomToken_ = cc.consumes();
+      }
+
+      //
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+        edm::ParameterSetDescription desc;
+        desc.add<edm::ESInputTag>("moduleindexer", edm::ESInputTag(""))->setComment("Module index tool");
+        desc.add<edm::ESInputTag>("cellindexer", edm::ESInputTag(""))->setComment("Dense cell index tool");
+        desc.add<edm::ESInputTag>("moduleinfo", edm::ESInputTag(""))->setComment("Module info table");
+        desc.add<edm::ESInputTag>("cellinfo", edm::ESInputTag(""))->setComment("Cell info table");        
+        descriptions.addWithDefaultLabel(desc);
+      }
+
+      //
+      std::optional<HGCalDenseIndexInfoHost> produce(const HGCalDenseIndexInfoRcd& iRecord) {
+
+        //geometry
+        auto const& geo = iRecord.getRecord<CaloGeometryRecord>().get(caloGeomToken_);
+
+        //get cell and module indexer
+        auto modIndexer = iRecord.getRecord<HGCalElectronicsMappingRcd>().get(moduleIndexTkn_);
+        auto cellIndexer = iRecord.getRecord<HGCalElectronicsMappingRcd>().get(cellIndexTkn_);
+
+        //get cell and module info
+        auto const& moduleInfo = iRecord.getRecord<HGCalElectronicsMappingRcd>().get(moduleInfoTkn_);
+        auto const& cellInfo = iRecord.getRecord<HGCalElectronicsMappingRcd>().get(cellInfoTkn_);
+
+        //declare the dense index info collection to be produced
+        //the size is determined by the module indexer
+        const uint32_t nIndices = modIndexer.getMaxDataSize();
+        HGCalDenseIndexInfoHost denseIdxInfo(nIndices, cms::alpakatools::host());
+        for(auto fedRS : modIndexer.fedReadoutSequences_) {
+
+          uint32_t fedId = fedRS.id;
+          for(size_t imod=0; imod<fedRS.moduleLUT_.size(); imod++) {
+            
+            //get the index of the module info, the number of words expected
+            //and the first channel dense index
+            int modIdx = fedRS.readoutTypes_[imod];
+            uint32_t nch = modIndexer.globalTypesNWords_[modIdx];
+            int off = fedRS.chDataOffsets_[imod];
+
+            //get necessary module info 
+            auto module_row = moduleInfo.view()[modIdx];
+            bool isSiPM =  module_row.isSiPM();
+            uint16_t typeidx = module_row.typeidx();
+            uint32_t eleid=module_row.eleid();
+            uint32_t detid=module_row.detid();
+
+            //get the appropriate geometry
+            DetId::Detector det = DetId(detid).det();
+            int subdet = ForwardSubdetector::ForwardEmpty;
+            const HGCalGeometry *hgcal_geom = static_cast<const HGCalGeometry *>(geo.getSubdetectorGeometry(det, subdet));
+
+            //get the offset to start reading the cell info from sequential
+            uint32_t cellInfoOffset = cellIndexer.offsets_[typeidx];
+
+            //now fill the information sequentially on the cells of this module
+            for(uint32_t ich=0; ich<nch; ich++) {
+
+              //finalize assigning the dense index
+              uint32_t denseIdx = off + ich;
+              auto row = denseIdxInfo.view()[denseIdx];
+              
+              //fill the fields
+              row.fedId() = fedId;
+              row.fedReadoutSeq() = imod;
+              row.chNumber() = ich;
+              
+              row.modInfoIdx() = modIdx;
+              uint32_t cellIdx = cellInfoOffset + ich;
+              row.cellInfoIdx() = cellIdx;
+              
+              auto cell_row = cellInfo.view()[cellIdx];
+              row.eleid() = eleid + cell_row.eleid();              
+
+              //assign det id only for full cells
+              row.detid() = 0;
+              if(cell_row.t()==1) {
+                if (isSiPM) {
+                  row.detid() = ::hgcal::mappingtools::getSiPMDetId(
+                    module_row.zside(), module_row.plane(), module_row.i2(), module_row.celltype(), 
+                    cell_row.i1(), cell_row.i2()
+                  );
+                } else {
+                  row.detid() = module_row.detid() + cell_row.detid();
+                }
+
+                //assign position from geometry
+                row.x()=0;
+                row.y()=0;
+                row.z()=0;
+                if(hgcal_geom!=nullptr) {
+                  GlobalPoint position = hgcal_geom->getPosition( row.detid() );
+                  row.x() = position.x();
+                  row.y() = position.y();
+                  row.z() = position.z();
+                }
+
+              }
+            }  // end cell loop
+          }  // end module loop
+        } // end fed readout sequence loop
+
+        return denseIdxInfo;
+      }  // end of produce()
+
+    private:
+      edm::ESGetToken<HGCalMappingModuleIndexer, HGCalElectronicsMappingRcd> moduleIndexTkn_;
+      edm::ESGetToken<HGCalMappingCellIndexer, HGCalElectronicsMappingRcd> cellIndexTkn_;
+      edm::ESGetToken<hgcal::HGCalMappingModuleParamHost, HGCalElectronicsMappingRcd> moduleInfoTkn_;
+      edm::ESGetToken<hgcal::HGCalMappingCellParamHost, HGCalElectronicsMappingRcd> cellInfoTkn_;
+      edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeomToken_;
+    };
+
+  }  // namespace hgcal
+
+}  // namespace ALPAKA_ACCELERATOR_NAMESPACE
+
+DEFINE_FWK_EVENTSETUP_ALPAKA_MODULE(hgcal::HGCalDenseIndexInfoESProducer);

--- a/Geometry/HGCalMapping/python/hgcalmapping_cff.py
+++ b/Geometry/HGCalMapping/python/hgcalmapping_cff.py
@@ -10,6 +10,10 @@ def customise_hgcalmapper(process,
     process.hgCalMappingESProducer.si = cms.FileInPath(sicells)
     process.hgCalMappingESProducer.sipm = cms.FileInPath(sipmcells)
 
+    if not hasattr(process, 'ProcessAcceleratorCUDA'):
+        print('Looks like Configuration.StandardSequences.Accelerators_cff was not yet loaded...loading')
+        process.load('Configuration.StandardSequences.Accelerators_cff')
+        
     process.hgCalMappingCellESProducer = cms.ESProducer('hgcal::HGCalMappingCellESProducer@alpaka',
                                                         filelist=cms.vstring(sicells, sipmcells),
                                                         cellindexer=cms.ESInputTag(''))

--- a/Geometry/HGCalMapping/python/hgcalmapping_cff.py
+++ b/Geometry/HGCalMapping/python/hgcalmapping_cff.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise_hgcalmapper(process,
+                          modules = 'Geometry/HGCalMapping/data/ModuleMaps/modulelocator_test.txt',
+                          sicells = 'Geometry/HGCalMapping/data/CellMaps/WaferCellMapTraces.txt',
+                          sipmcells = 'Geometry/HGCalMapping/data/CellMaps/channels_sipmontile.hgcal.txt'):
+
+    process.load('Geometry.HGCalMapping.hgCalMappingESProducer_cfi')
+    process.hgCalMappingESProducer.modules = cms.FileInPath(modules)
+    process.hgCalMappingESProducer.si = cms.FileInPath(sicells)
+    process.hgCalMappingESProducer.sipm = cms.FileInPath(sipmcells)
+
+    process.hgCalMappingCellESProducer = cms.ESProducer('hgcal::HGCalMappingCellESProducer@alpaka',
+                                                        filelist=cms.vstring(sicells, sipmcells),
+                                                        cellindexer=cms.ESInputTag(''))
+    process.hgCalMappingModuleESProducer = cms.ESProducer('hgcal::HGCalMappingModuleESProducer@alpaka',
+                                                          filename=cms.FileInPath(modules),
+                                                          moduleindexer=cms.ESInputTag(''))
+    process.hgCalDenseIndexInfoESProducer = cms.ESProducer('hgcal::HGCalDenseIndexInfoESProducer@alpaka',
+                                                           moduleindexer=cms.ESInputTag('') )
+    
+    return process

--- a/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
+++ b/Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc
@@ -16,9 +16,10 @@
 // #include "HeterogeneousCore/AlpakaInterface/interface/CopyToDevice.h"
 
 #include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
+#include "CondFormats/DataRecord/interface/HGCalDenseIndexInfoRcd.h"
 #include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"
 #include "CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h"
-#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHostCollection.h"
+#include "CondFormats/HGCalObjects/interface/HGCalMappingParameterHost.h"
 #include "Geometry/HGCalMapping/interface/HGCalMappingTools.h"
 
 namespace {
@@ -37,8 +38,8 @@ class HGCalMappingESSourceTester : public edm::one::EDAnalyzer<> {
 public:
   explicit HGCalMappingESSourceTester(const edm::ParameterSet&);
   static void fillDescriptions(edm::ConfigurationDescriptions&);
-  std::map<uint32_t, uint32_t> mapGeoToElectronics(const hgcal::HGCalMappingModuleParamHostCollection& modules,
-                                                   const hgcal::HGCalMappingCellParamHostCollection& cells,
+  std::map<uint32_t, uint32_t> mapGeoToElectronics(const hgcal::HGCalMappingModuleParamHost& modules,
+                                                   const hgcal::HGCalMappingCellParamHost& cells,
                                                    bool geo2ele,
                                                    bool sipm);
 
@@ -47,14 +48,16 @@ private:
 
   edm::ESWatcher<HGCalElectronicsMappingRcd> cfgWatcher_;
   edm::ESGetToken<HGCalMappingCellIndexer, HGCalElectronicsMappingRcd> cellIndexTkn_;
-  edm::ESGetToken<hgcal::HGCalMappingCellParamHostCollection, HGCalElectronicsMappingRcd> cellTkn_;
+  edm::ESGetToken<hgcal::HGCalMappingCellParamHost, HGCalElectronicsMappingRcd> cellTkn_;
   edm::ESGetToken<HGCalMappingModuleIndexer, HGCalElectronicsMappingRcd> moduleIndexTkn_;
-  edm::ESGetToken<hgcal::HGCalMappingModuleParamHostCollection, HGCalElectronicsMappingRcd> moduleTkn_;
+  edm::ESGetToken<hgcal::HGCalMappingModuleParamHost, HGCalElectronicsMappingRcd> moduleTkn_;
+  edm::ESGetToken<hgcal::HGCalDenseIndexInfoHost, HGCalDenseIndexInfoRcd> denseIndexTkn_;
+
 };
 
 //
 HGCalMappingESSourceTester::HGCalMappingESSourceTester(const edm::ParameterSet& iConfig)
-    : cellIndexTkn_(esConsumes()), cellTkn_(esConsumes()), moduleIndexTkn_(esConsumes()), moduleTkn_(esConsumes()) {}
+    : cellIndexTkn_(esConsumes()), cellTkn_(esConsumes()), moduleIndexTkn_(esConsumes()), moduleTkn_(esConsumes()), denseIndexTkn_(esConsumes()) {}
 
 //
 void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -219,7 +222,7 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
       assert(geo2ele.count(it.second) == 1);
       assert(geo2ele[it.second] == it.first);
     }
-
+    
     return true;
   };
 
@@ -314,6 +317,18 @@ void HGCalMappingESSourceTester::analyze(const edm::Event& iEvent, const edm::Ev
   assert(did.layer() == modules.view()[modidx].plane());
   assert(did.cellU() == cells.view()[cellidx].i1());
   assert(did.cellV() == cells.view()[cellidx].i2());
+
+  //test dense index token
+  auto const& denseIndexInfo = iSetup.getData(denseIndexTkn_);
+  printf( "Retrieved %d dense index info\n",denseIndexInfo.view().metadata().size());
+  int nindices = denseIndexInfo.view().metadata().size();
+  printf("fedId fedReadoutSeq detId eleid modix cellidx channel x y z");
+  for(int i=0; i<nindices; i++) {
+    auto row = denseIndexInfo.view()[i];
+    printf("%d %d 0x%x 0x%x %d %d %d %f %f %f\n",
+      row.fedId(),row.fedReadoutSeq(),row.detid(),row.eleid(),row.modInfoIdx(),row.cellInfoIdx(),row.chNumber(),row.x(),row.y(),row.z() );
+  }
+
 }
 
 //
@@ -324,8 +339,8 @@ void HGCalMappingESSourceTester::fillDescriptions(edm::ConfigurationDescriptions
 
 //
 std::map<uint32_t, uint32_t> HGCalMappingESSourceTester::mapGeoToElectronics(
-    const hgcal::HGCalMappingModuleParamHostCollection& modules,
-    const hgcal::HGCalMappingCellParamHostCollection& cells,
+    const hgcal::HGCalMappingModuleParamHost& modules,
+    const hgcal::HGCalMappingCellParamHost& cells,
     bool geo2ele,
     bool sipm) {
   //loop over different modules
@@ -366,14 +381,6 @@ std::map<uint32_t, uint32_t> HGCalMappingESSourceTester::mapGeoToElectronics(
       if (jcell.t() != 1)
         continue;
 
-      // uint32_t elecid = ::hgcal::mappingtools::getElectronicsId(imod.zside(),
-      //                                                         imod.fedid(),
-      //                                                         imod.captureblockidx(),
-      //                                                         imod.econdidx(),
-      //                                                         jcell.chip(),
-      //                                                         jcell.half(),
-      //                                                         jcell.seq());
-
       uint32_t elecid = imod.eleid() + jcell.eleid();
 
       uint32_t geoid(0);
@@ -382,14 +389,6 @@ std::map<uint32_t, uint32_t> HGCalMappingESSourceTester::mapGeoToElectronics(
         geoid = ::hgcal::mappingtools::getSiPMDetId(
             imod.zside(), imod.plane(), imod.i2(), imod.celltype(), jcell.i1(), jcell.i2());
       } else {
-        // geoid = ::hgcal::mappingtools::getSiDetId(imod.zside(),
-        //                                         imod.plane(),
-        //                                         imod.i1(),
-        //                                         imod.i2(),
-        //                                         imod.celltype(),
-        //                                         jcell.i1(),
-        //                                         jcell.i2());
-
         geoid = imod.detid() + jcell.detid();
       }
 

--- a/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
+++ b/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
@@ -18,7 +18,6 @@ process.maxEvents = cms.untracked.PSet(
 )
 
 #electronics mapping
-process.load('Configuration.StandardSequences.Accelerators_cff')
 from Geometry.HGCalMapping.hgcalmapping_cff import customise_hgcalmapper
 process = customise_hgcalmapper(process)
 

--- a/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
+++ b/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
@@ -32,7 +32,12 @@ process.hgCalMappingCellESProducer = cms.ESProducer('hgcal::HGCalMappingCellESPr
 process.hgCalMappingModuleESProducer = cms.ESProducer('hgcal::HGCalMappingModuleESProducer@alpaka',
                                                       filename=cms.FileInPath(options.modules),
                                                       moduleindexer=cms.ESInputTag('') )
+process.hgCalDenseIndexInfoESProducer = cms.ESProducer('hgcal::HGCalDenseIndexInfoESProducer@alpaka',
+                                                       moduleindexer=cms.ESInputTag('') )
 
+#Geometry
+process.load('Configuration.Geometry.GeometryExtended2026D99Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2026D99_cff')
 
 #tester
 process.tester = cms.EDAnalyzer('HGCalMappingESSourceTester')

--- a/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
+++ b/Geometry/HGCalMapping/test/testMappingModuleIndexer_cfg.py
@@ -17,27 +17,13 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
 )
 
-#ESSources/Producers for the logical mapping
-#indexers
-process.load('Geometry.HGCalMapping.hgCalMappingESProducer_cfi')
-process.hgCalMappingESProducer.modules = cms.FileInPath(options.modules)
-process.hgCalMappingESProducer.si = cms.FileInPath(options.sicells)
-process.hgCalMappingESProducer.sipm = cms.FileInPath(options.sipmcells)
-
-#cells and modules info
+#electronics mapping
 process.load('Configuration.StandardSequences.Accelerators_cff')
-process.hgCalMappingCellESProducer = cms.ESProducer('hgcal::HGCalMappingCellESProducer@alpaka',
-                                                      filelist=cms.vstring(options.sicells,options.sipmcells),
-                                                      cellindexer=cms.ESInputTag('') )
-process.hgCalMappingModuleESProducer = cms.ESProducer('hgcal::HGCalMappingModuleESProducer@alpaka',
-                                                      filename=cms.FileInPath(options.modules),
-                                                      moduleindexer=cms.ESInputTag('') )
-process.hgCalDenseIndexInfoESProducer = cms.ESProducer('hgcal::HGCalDenseIndexInfoESProducer@alpaka',
-                                                       moduleindexer=cms.ESInputTag('') )
+from Geometry.HGCalMapping.hgcalmapping_cff import customise_hgcalmapper
+process = customise_hgcalmapper(process)
 
 #Geometry
 process.load('Configuration.Geometry.GeometryExtended2026D99Reco_cff')
-#process.load('Configuration.Geometry.GeometryExtended2026D99_cff')
 
 #tester
 process.tester = cms.EDAnalyzer('HGCalMappingESSourceTester')


### PR DESCRIPTION
#### PR description:

This introduces a new ESProducer which joins both the logical and the geometry for HGCAL.
A new collection `HGCalDenseIndexInfoSoA` is put in the event setup with the following fields

* `fedId` and `fedReadoutSeq` : the FED identifier and the index of the module in the readout sequence of the FED
* `detid` the HGCalDetId raw value
* `eleid` the HGCalElectronicsId raw value
* `modInfoIdx` the index to use to read the module info from the `HGCalMappingModuleParamSoA`
* `cellInfoIdx` the index to use to read the cell info from the `HGCalMappingCellParamSoA`
* `chNumber` a sequential index of the channel for all the ROCs read by an ECON-D
* `x,y,z` the cartesian coordinates from the geometry

As the ESProducer needed two records available (HGCalElectronicsMappingRcd and CaloGeometryRecord) I have created a new record which depends on these two. The new record is called HGCalDenseIndexInfoRcd.

#### PR validation:

I have used the test module locator file available and added some printouts to Geometry/HGCalMapping/test/HGCalMappingESSourceTester.cc