### PR TITLE
Implement TH2Poly in DQM based on 14e856f

### DIFF
--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -251,6 +251,20 @@ namespace dqm {
             /* forceReplace */ true);
       }
       template <typename FUNC = NOOP, std::enable_if_t<not std::is_arithmetic<FUNC>::value, int> = 0>
+      MonitorElement* book2DPoly(TString const& name,
+                                 TString const& title,
+                                 double lowX,
+                                 double highX,
+                                 double lowY,
+                                 double highY,
+                                 FUNC onbooking = NOOP()) {
+        return bookME(name, MonitorElementData::Kind::TH2Poly, [=]() {
+          auto th2poly = new TH2Poly(name, title, lowX, highX, lowY, highY);
+          onbooking(th2poly);
+          return th2poly;
+        });
+      }
+      template <typename FUNC = NOOP, std::enable_if_t<not std::is_arithmetic<FUNC>::value, int> = 0>
       MonitorElement* book2S(TString const& name,
                              TString const& title,
                              int nchX,

--- a/DQMServices/Core/interface/MonitorElement.h
+++ b/DQMServices/Core/interface/MonitorElement.h
@@ -21,11 +21,13 @@
 #include "TH2S.h"
 #include "TH2I.h"
 #include "TH2D.h"
+#include "TH2Poly.h"
 #include "TH3F.h"
 #include "TProfile.h"
 #include "TProfile2D.h"
 #include "TObjString.h"
 #include "TAxis.h"
+#include "TGraph.h"
 
 #include <mutex>
 #include <memory>
@@ -398,6 +400,7 @@ namespace dqm::impl {
     virtual const std::string &getStringValue() const;
 
     // non-const -- thread safety and semantical issues
+    virtual void addBin(TGraph *graph);
     virtual void setBinContent(int binx, double content);
     virtual void setBinContent(int binx, int biny, double content);
     virtual void setBinContent(int binx, int biny, int binz, double content);
@@ -443,6 +446,7 @@ namespace dqm::impl {
     virtual TH2S *getTH2S();
     virtual TH2I *getTH2I();
     virtual TH2D *getTH2D();
+    virtual TH2Poly *getTH2Poly();
     virtual TH3F *getTH3F();
     virtual TProfile *getTProfile();
     virtual TProfile2D *getTProfile2D();
@@ -510,6 +514,10 @@ namespace dqm::legacy {
     using dqm::reco::MonitorElement::getTH2D;
     virtual TH2D *getTH2D() const {
       return const_cast<dqm::legacy::MonitorElement *>(this)->dqm::reco::MonitorElement::getTH2D();
+    };
+    using dqm::reco::MonitorElement::getTH2Poly;
+    virtual TH2Poly *getTH2Poly() const {
+      return const_cast<dqm::legacy::MonitorElement *>(this)->dqm::reco::MonitorElement::getTH2Poly();
     };
     using dqm::reco::MonitorElement::getTH3F;
     virtual TH3F *getTH3F() const {

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -243,6 +243,8 @@ namespace dqm::impl {
       static_cast<TH2D *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, yw, 1);
     else if (kind() == Kind::TH2I)
       static_cast<TH2I *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, yw, 1);
+    else if (kind() == Kind::TH2Poly)
+      static_cast<TH2Poly *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, yw, 1);
     else if (kind() == Kind::TPROFILE)
       static_cast<TProfile *>(accessRootObject(access, __PRETTY_FUNCTION__, 1))->Fill(x, yw, 1);
     else
@@ -329,6 +331,8 @@ namespace dqm::impl {
       static_cast<TH2D *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, y, zw);
     else if (kind() == Kind::TH2I)
       static_cast<TH2I *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, y, zw);
+    else if (kind() == Kind::TH2Poly)
+      static_cast<TH2Poly *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, y, zw);
     else if (kind() == Kind::TH3F)
       static_cast<TH3F *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->Fill(x, y, zw, 1);
     else if (kind() == Kind::TPROFILE)
@@ -688,6 +692,16 @@ namespace dqm::impl {
 
   /*** setter methods (wrapper around ROOT methods) ****/
   //
+  /// set polygon bin (TH2Poly)
+  void MonitorElement::addBin(TGraph *graph) {
+    auto access = this->accessMut();
+    if (kind() == Kind::TH2Poly) {
+      static_cast<TH2Poly *>(accessRootObject(access, __PRETTY_FUNCTION__, 2))->AddBin(graph);
+    } else {
+      incompatible(__PRETTY_FUNCTION__);
+    }
+  }
+
   /// set content of bin (1-D)
   void MonitorElement::setBinContent(int binx, double content) {
     auto access = this->accessMut();
@@ -1030,6 +1044,12 @@ namespace dqm::impl {
     auto access = this->accessMut();
     assert(kind() == Kind::TH2D);
     return static_cast<TH2D *>(accessRootObject(access, __PRETTY_FUNCTION__, 2));
+  }
+
+  TH2Poly *MonitorElement::getTH2Poly() {
+    auto access = this->accessMut();
+    assert(kind() == Kind::TH2Poly);
+    return static_cast<TH2Poly *>(accessRootObject(access, __PRETTY_FUNCTION__, 2));
   }
 
   TH3F *MonitorElement::getTH3F() {

--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -16,6 +16,7 @@
 #include <TH2F.h>
 #include <TH2S.h>
 #include <TH2D.h>
+#include <TH2Poly.h>
 #include <TH3F.h>
 #include <TProfile.h>
 #include <TProfile2D.h>

--- a/DataFormats/Histograms/interface/MonitorElementCollection.h
+++ b/DataFormats/Histograms/interface/MonitorElementCollection.h
@@ -138,6 +138,7 @@ struct MonitorElementData {
     TH2S = 0x21,
     TH2D = 0x22,
     TH2I = 0x23,
+    TH2Poly = 0x24,
     TH3F = 0x30,
     TPROFILE = 0x40,
     TPROFILE2D = 0x41


### PR DESCRIPTION
#### PR description:
Port DQM TH2Poly feature into `dev/hackathon_base_CMSSW_14_1_X`. These commits are necessary for creating polygonal wafer maps in the DQM harvester.

#### PR validation:
Fix compilation errors related to missing TH2Poly in DQM service in `HGCalCommissioning/DQM/plugins/HGCalSysValDigisHarvester.cc`.

#### Relevant links:
https://gitlab.cern.ch/hgcal-dpg/hgcal-comm/-/merge_requests/8
https://gitlab.cern.ch/ykao/hgcal-comm/-/blob/dev/test/DQM/plugins/HGCalSysValDigisHarvester.cc
