### PR TITLE
Flag in digi SoA

### DIFF
--- a/DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h
+++ b/DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h
@@ -108,12 +108,17 @@ namespace hgcal {
   };
 
   enum DIGI_FLAG {
+    //Flags for normal ECON-D
     FULL_READOUT = 0x0000,
     ZS_ADCm1 = 0x0001,
     ZS_ToA = 0x0002,
     ZS_ToA_ADCm1 = 0x0003,
     ZS_ADC = 0x0004,
-    Invalid = 0x0005
+    Invalid = 0x0005,
+    //Flags for passthrough ECON-D
+    Normal = 0x8000,
+    Characterization = 0x8001,
+    Inactive = 0x8002,
   };
 }  // namespace hgcal
 

--- a/DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h
+++ b/DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h
@@ -106,6 +106,15 @@ namespace hgcal {
     SLINK_STATUS_MASK = 0xffff,
     SLINK_STATUS_POS = 0,
   };
+
+  enum DIGI_FLAG {
+    FULL_READOUT = 0x0000,
+    ZS_ADCm1 = 0x0001,
+    ZS_ToA = 0x0002,
+    ZS_ToA_ADCm1 = 0x0003,
+    ZS_ADC = 0x0004,
+    Invalid = 0x0005
+  };
 }  // namespace hgcal
 
 #endif

--- a/DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h
+++ b/DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h
@@ -113,12 +113,12 @@ namespace hgcal {
     ZS_ADCm1 = 0x0001,
     ZS_ToA = 0x0002,
     ZS_ToA_ADCm1 = 0x0003,
-    ZS_ADC = 0x0004,
-    Invalid = 0x0005,
+    Invalid = 0x0004,
     //Flags for passthrough ECON-D
     Normal = 0x8000,
     Characterization = 0x8001,
-    Inactive = 0x8002,
+    //Flag for digi not in raw data
+    NotAvailable = 0xFFFF
   };
 }  // namespace hgcal
 

--- a/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
+++ b/EventFilter/HGCalRawToDigi/interface/HGCalUnpacker.h
@@ -11,6 +11,7 @@
 #ifndef EventFilter_HGCalRawToDigi_HGCalUnpacker_h
 #define EventFilter_HGCalRawToDigi_HGCalUnpacker_h
 
+#include "DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/HGCalDigi/interface/HGCalDigiHost.h"
 #include "DataFormats/HGCalDigi/interface/HGCalECONDInfoHost.h"
@@ -130,7 +131,22 @@ private:
                                             0b1111111111,
                                             0b1111111111,
                                             0b1111111111};
-
+  constexpr static uint16_t flags_[16] = {hgcal::DIGI_FLAG::ZS_ToA,
+                                          hgcal::DIGI_FLAG::ZS_ToA_ADCm1,
+                                          hgcal::DIGI_FLAG::ZS_ToA,
+                                          hgcal::DIGI_FLAG::ZS_ADCm1,
+                                          hgcal::DIGI_FLAG::FULL_READOUT,
+                                          hgcal::DIGI_FLAG::FULL_READOUT,
+                                          hgcal::DIGI_FLAG::FULL_READOUT,
+                                          hgcal::DIGI_FLAG::FULL_READOUT,
+                                          hgcal::DIGI_FLAG::Invalid,
+                                          hgcal::DIGI_FLAG::Invalid,
+                                          hgcal::DIGI_FLAG::Invalid,
+                                          hgcal::DIGI_FLAG::Invalid,
+                                          hgcal::DIGI_FLAG::FULL_READOUT,
+                                          hgcal::DIGI_FLAG::FULL_READOUT,
+                                          hgcal::DIGI_FLAG::FULL_READOUT,
+                                          hgcal::DIGI_FLAG::FULL_READOUT};
   constexpr static uint32_t erxBodyBits_[16] = {24, 16, 24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32};
 
   // HGCalUnpackerConfig config_;

--- a/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
+++ b/EventFilter/HGCalRawToDigi/plugins/HGCalRawToDigi.cc
@@ -12,6 +12,7 @@
 #include "DataFormats/HGCalDigi/interface/HGCalElectronicsId.h"
 #include "DataFormats/HGCalDigi/interface/HGCalDigiHost.h"
 #include "DataFormats/HGCalDigi/interface/HGCalECONDInfoHost.h"
+#include "DataFormats/HGCalDigi/interface/HGCalRawDataDefinitions.h"
 
 #include "CondFormats/DataRecord/interface/HGCalElectronicsMappingRcd.h"
 #include "CondFormats/HGCalObjects/interface/HGCalMappingModuleIndexer.h"
@@ -112,6 +113,9 @@ void HGCalRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
   // retrieve the FED raw data
   const auto& raw_data = iEvent.get(fedRawToken_);
 
+  for(int32_t i=0; i < digis.view().metadata().size();i++){
+    digis.view()[i].flags() = hgcal::DIGI_FLAG::NotAvailable;
+  }
   for (unsigned fedId = 0; fedId < moduleIndexer_.nfeds_; ++fedId) {
     const auto& fed_data = raw_data.FEDData(fedId);
     if (fed_data.size() == 0)

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -105,6 +105,7 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
     ++ptr;
     // parse Capture Block body (ECON-Ds)
     for (uint32_t econdIdx = 0; econdIdx < HGCalMappingModuleIndexer::maxECONDperCB_; econdIdx++) {
+
       auto econd_pkt_status = (cb_header >> (3 * econdIdx)) & 0b111;
       LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx << ", econdIdx = " << econdIdx
                 << ", econd_pkt_status = " << econd_pkt_status;
@@ -112,13 +113,14 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
         // always increment the global ECON-D index (unless inactive/unconnected)
         globalECONDIdx++;
       }
+      
       bool pkt_exists =
-          (econd_pkt_status == backend::ECONDPacketStatus::Normal) ||
-          (econd_pkt_status == backend::ECONDPacketStatus::PayloadCRCError) ||
-          (econd_pkt_status == backend::ECONDPacketStatus::EventIDMismatch) ||
-          (econd_pkt_status == backend::ECONDPacketStatus::BCIDOrbitIDMismatch);  // TODO: `BCIDOrbitIDMismatch`
+	(econd_pkt_status == backend::ECONDPacketStatus::Normal) ||
+	(econd_pkt_status == backend::ECONDPacketStatus::PayloadCRCError) ||
+	(econd_pkt_status == backend::ECONDPacketStatus::EventIDMismatch) ||
+	(fedConfig.mismatchPassthroughMode && econd_pkt_status == backend::ECONDPacketStatus::BCIDOrbitIDMismatch);
       if (!pkt_exists) {
-        continue;
+	continue;
       }
 
       // ECON-D header (two 32b words)
@@ -131,10 +133,12 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
       if (((econd_headers[0] >> ECOND_FRAME::HEADER_POS) & ECOND_FRAME::HEADER_MASK) !=
           fedConfig.econds[globalECONDIdx].headerMarker) {
         econdInfo.view()[ECONDdenseIdx].exception() = 3;
-        throw cms::Exception("CorruptData")
-            << "Expected a ECON-D header at word " << std::dec << (uint32_t)(ptr - header) << "/0x" << std::hex
-            << (uint32_t)(ptr - header) << " (marker: 0x" << fedConfig.econds[globalECONDIdx].headerMarker
-            << "), got 0x" << econd_headers[0] << ".";
+
+	//DO NOT THROW!! just flag as exception and try to continue
+        //throw cms::Exception("CorruptData")
+        //    << "Expected a ECON-D header at word " << std::dec << (uint32_t)(ptr - header) << "/0x" << std::hex
+	//     << (uint32_t)(ptr - header) << " (marker: 0x" << fedConfig.econds[globalECONDIdx].headerMarker
+        //    << "), got 0x" << econd_headers[0] << ".";
       }
       ++ptr;
 
@@ -151,7 +155,8 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
                              (((econd_headers[1] >> ECOND_FRAME::BITS_POS) & 0b1) << ECONDFlag::BITS_POS);
       econdInfo.view()[ECONDdenseIdx].payloadLength() = (uint16_t)econd_payload_length;
       econdInfo.view()[ECONDdenseIdx].econdFlag() = (uint8_t)econdFlag;
-
+      econdInfo.view()[ECONDdenseIdx].exception() = 0;
+      
       // convert ECON-D packets into 32b words -- need to swap the order of the two 32b words in the 64b word
       auto econd_payload = to_econd_payload(ptr, econd_payload_length);
 
@@ -162,8 +167,8 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
                 << ", econd_headers = " << std::hex << std::setfill('0') << std::setw(8) << econd_headers[0] << " "
                 << econd_headers[1] << std::dec << ", econd_payload_length = " << econd_payload_length;
 
-      //quality check for ECON-D
-      if (econd_pkt_status != 0b000 || (((econd_headers[0] >> ECOND_FRAME::HT_POS) & ECOND_FRAME::HT_MASK) >= 0b10) ||
+      //quality check for ECON-D (no need to check again econd_pkt_status here again)
+      if ((((econd_headers[0] >> ECOND_FRAME::HT_POS) & ECOND_FRAME::HT_MASK) >= 0b10) ||
           (((econd_headers[0] >> ECOND_FRAME::EBO_POS) & ECOND_FRAME::EBO_MASK) >= 0b10) ||
           (((econd_headers[0] >> ECOND_FRAME::BITM_POS) & 0b1) == 0) ||
           (((econd_headers[0] >> ECOND_FRAME::BITM_POS) & 0b1) == 0) || econd_payload_length == 0 || headerOnlyMode) {
@@ -264,13 +269,14 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
 
             // check if the channel has data
-            if (((erxHeader >> channelIdx) & 1) == 0) {
+	    if (((erxHeader >> channelIdx) & 1) == 0) {
               digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::ZS_ADC;
               continue;
             }
-            // check if in characteristic mode
+
+            // check if in characterization mode
             if (fedConfig.econds[globalECONDIdx].rocs[erxIdx / 2].charMode) {
-              //characteristic mode
+              //characterization mode
               digis.view()[denseIdx].tctp() = (econd_payload[iword] >> 30) & 0b11;
               digis.view()[denseIdx].adcm1() = 0;
               digis.view()[denseIdx].adc() = (econd_payload[iword] >> 20) & 0b1111111111;
@@ -278,7 +284,8 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
               digis.view()[denseIdx].toa() = econd_payload[iword] & 0b1111111111;
               digis.view()[denseIdx].cm() = cmSum;
               digis.view()[denseIdx].flags() = 0;
-            } else {
+
+	    } else {
               //not characteristic mode
               digis.view()[denseIdx].tctp() = (econd_payload[iword] >> 30) & 0b11;
 
@@ -300,13 +307,14 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
       }
       // end of ECON-D parsing
       if (iword != econd_payload_length - 1) {
-        econdInfo.view()[ECONDdenseIdx].exception() = 5;
-        throw cms::Exception("CorruptData")
-            << "Mismatch between unpacked and expected ECON-D #" << (int)globalECONDIdx << " payload length\n"
-            << "  unpacked payload length=" << iword + 1 << "\n"
-            << "  expected payload length=" << econd_payload_length;
+        econdInfo.view()[ECONDdenseIdx].exception() = 5;	
+	//SHOULD NOT THROW!!!!
+        //throw cms::Exception("CorruptData")
+        //    << "Mismatch between unpacked and expected ECON-D #" << (int)globalECONDIdx << " payload length\n"
+        //    << "  unpacked payload length=" << iword + 1 << "\n"
+        //    << "  expected payload length=" << econd_payload_length;
       }
-      econdInfo.view()[ECONDdenseIdx].exception() = 0;
+
     }
     // skip the padding word as capture blocks are padded to 128b
     if (std::distance(ptr, header) % 2) {

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -105,7 +105,6 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
     ++ptr;
     // parse Capture Block body (ECON-Ds)
     for (uint32_t econdIdx = 0; econdIdx < HGCalMappingModuleIndexer::maxECONDperCB_; econdIdx++) {
-
       auto econd_pkt_status = (cb_header >> (3 * econdIdx)) & 0b111;
       LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx << ", econdIdx = " << econdIdx
                 << ", econd_pkt_status = " << econd_pkt_status;
@@ -113,14 +112,13 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
         // always increment the global ECON-D index (unless inactive/unconnected)
         globalECONDIdx++;
       }
-      
       bool pkt_exists =
-	(econd_pkt_status == backend::ECONDPacketStatus::Normal) ||
-	(econd_pkt_status == backend::ECONDPacketStatus::PayloadCRCError) ||
-	(econd_pkt_status == backend::ECONDPacketStatus::EventIDMismatch) ||
-	(fedConfig.mismatchPassthroughMode && econd_pkt_status == backend::ECONDPacketStatus::BCIDOrbitIDMismatch);
+          (econd_pkt_status == backend::ECONDPacketStatus::Normal) ||
+          (econd_pkt_status == backend::ECONDPacketStatus::PayloadCRCError) ||
+          (econd_pkt_status == backend::ECONDPacketStatus::EventIDMismatch) ||
+          (econd_pkt_status == backend::ECONDPacketStatus::BCIDOrbitIDMismatch);  // TODO: `BCIDOrbitIDMismatch`
       if (!pkt_exists) {
-	continue;
+        continue;
       }
 
       // ECON-D header (two 32b words)
@@ -133,12 +131,10 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
       if (((econd_headers[0] >> ECOND_FRAME::HEADER_POS) & ECOND_FRAME::HEADER_MASK) !=
           fedConfig.econds[globalECONDIdx].headerMarker) {
         econdInfo.view()[ECONDdenseIdx].exception() = 3;
-
-	//DO NOT THROW!! just flag as exception and try to continue
-        //throw cms::Exception("CorruptData")
-        //    << "Expected a ECON-D header at word " << std::dec << (uint32_t)(ptr - header) << "/0x" << std::hex
-	//     << (uint32_t)(ptr - header) << " (marker: 0x" << fedConfig.econds[globalECONDIdx].headerMarker
-        //    << "), got 0x" << econd_headers[0] << ".";
+        throw cms::Exception("CorruptData")
+            << "Expected a ECON-D header at word " << std::dec << (uint32_t)(ptr - header) << "/0x" << std::hex
+            << (uint32_t)(ptr - header) << " (marker: 0x" << fedConfig.econds[globalECONDIdx].headerMarker
+            << "), got 0x" << econd_headers[0] << ".";
       }
       ++ptr;
 
@@ -155,8 +151,7 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
                              (((econd_headers[1] >> ECOND_FRAME::BITS_POS) & 0b1) << ECONDFlag::BITS_POS);
       econdInfo.view()[ECONDdenseIdx].payloadLength() = (uint16_t)econd_payload_length;
       econdInfo.view()[ECONDdenseIdx].econdFlag() = (uint8_t)econdFlag;
-      econdInfo.view()[ECONDdenseIdx].exception() = 0;
-      
+
       // convert ECON-D packets into 32b words -- need to swap the order of the two 32b words in the 64b word
       auto econd_payload = to_econd_payload(ptr, econd_payload_length);
 
@@ -167,8 +162,8 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
                 << ", econd_headers = " << std::hex << std::setfill('0') << std::setw(8) << econd_headers[0] << " "
                 << econd_headers[1] << std::dec << ", econd_payload_length = " << econd_payload_length;
 
-      //quality check for ECON-D (no need to check again econd_pkt_status here again)
-      if ((((econd_headers[0] >> ECOND_FRAME::HT_POS) & ECOND_FRAME::HT_MASK) >= 0b10) ||
+      //quality check for ECON-D
+      if (econd_pkt_status != 0b000 || (((econd_headers[0] >> ECOND_FRAME::HT_POS) & ECOND_FRAME::HT_MASK) >= 0b10) ||
           (((econd_headers[0] >> ECOND_FRAME::EBO_POS) & ECOND_FRAME::EBO_MASK) >= 0b10) ||
           (((econd_headers[0] >> ECOND_FRAME::BITM_POS) & 0b1) == 0) ||
           (((econd_headers[0] >> ECOND_FRAME::BITM_POS) & 0b1) == 0) || econd_payload_length == 0 || headerOnlyMode) {
@@ -214,7 +209,7 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
 
             // check if the channel has data
             if (((erxHeader >> channelIdx) & 1) == 0) {
-	      //digis.view()[denseIdx].flags() =  FIXME! set flag as suppressed
+              digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::ZS_ADC;  
               continue;
             }
 
@@ -269,14 +264,13 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
 
             // check if the channel has data
-	    if (((erxHeader >> channelIdx) & 1) == 0) {
-	      //digis.view()[denseIdx].flags() =  FIXME! set flag as suppressed
+            if (((erxHeader >> channelIdx) & 1) == 0) {
+              digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::ZS_ADC;
               continue;
             }
-
-            // check if in characterization mode
+            // check if in characteristic mode
             if (fedConfig.econds[globalECONDIdx].rocs[erxIdx / 2].charMode) {
-              //characterization mode
+              //characteristic mode
               digis.view()[denseIdx].tctp() = (econd_payload[iword] >> 30) & 0b11;
               digis.view()[denseIdx].adcm1() = 0;
               digis.view()[denseIdx].adc() = (econd_payload[iword] >> 20) & 0b1111111111;
@@ -284,8 +278,7 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
               digis.view()[denseIdx].toa() = econd_payload[iword] & 0b1111111111;
               digis.view()[denseIdx].cm() = cmSum;
               digis.view()[denseIdx].flags() = 0;
-
-	    } else {
+            } else {
               //not characteristic mode
               digis.view()[denseIdx].tctp() = (econd_payload[iword] >> 30) & 0b11;
 
@@ -299,7 +292,7 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
               }
               digis.view()[denseIdx].toa() = econd_payload[iword] & 0b1111111111;
               digis.view()[denseIdx].cm() = cmSum;
-              digis.view()[denseIdx].flags() = 0;
+              digis.view()[denseIdx].flags() = flags_[iword];
             }
             iword += 1;
           }
@@ -307,14 +300,13 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
       }
       // end of ECON-D parsing
       if (iword != econd_payload_length - 1) {
-        econdInfo.view()[ECONDdenseIdx].exception() = 5;	
-	//SHOULD NOT THROW!!!!
-        //throw cms::Exception("CorruptData")
-        //    << "Mismatch between unpacked and expected ECON-D #" << (int)globalECONDIdx << " payload length\n"
-        //    << "  unpacked payload length=" << iword + 1 << "\n"
-        //    << "  expected payload length=" << econd_payload_length;
+        econdInfo.view()[ECONDdenseIdx].exception() = 5;
+        throw cms::Exception("CorruptData")
+            << "Mismatch between unpacked and expected ECON-D #" << (int)globalECONDIdx << " payload length\n"
+            << "  unpacked payload length=" << iword + 1 << "\n"
+            << "  expected payload length=" << econd_payload_length;
       }
-
+      econdInfo.view()[ECONDdenseIdx].exception() = 0;
     }
     // skip the padding word as capture blocks are padded to 128b
     if (std::distance(ptr, header) % 2) {

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -188,6 +188,10 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
         for (uint32_t erxIdx = 0; erxIdx < erxMax; erxIdx++) {
           // check if the eRx is enabled
           if ((enabledErx >> erxIdx & 1) == 0) {
+            for (uint32_t channelIdx = 0; channelIdx < maxChPerErxNonCM; channelIdx++) {
+              uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
+              digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::ZS_ADC;
+            }
             continue;
           }
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
@@ -245,6 +249,10 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
         for (uint32_t erxIdx = 0; erxIdx < erxMax; erxIdx++) {
           // check if the eRx is enabled
           if ((enabledErx >> erxIdx & 1) == 0) {
+            for (uint32_t channelIdx = 0; channelIdx < maxChPerErxNonCM; channelIdx++) {
+              uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
+              digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::Inactive;
+            }
             continue;
           }
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -19,9 +19,6 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
                                  hgcaldigi::HGCalDigiHost& digis,
                                  hgcaldigi::HGCalECONDInfoHost& econdInfo,
                                  bool headerOnlyMode) {
-  // number of non-CM channels (= 37)
-  constexpr uint16_t maxChPerErxNonCM = HGCalMappingCellIndexer::maxChPerErx_ - 2;
-
   // ReadoutSequence object for this FED
   const auto& fedReadoutSequence = moduleIndexer.fedReadoutSequences_[fedId];
   // Configuration object for this FED
@@ -188,10 +185,6 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
         for (uint32_t erxIdx = 0; erxIdx < erxMax; erxIdx++) {
           // check if the eRx is enabled
           if ((enabledErx >> erxIdx & 1) == 0) {
-            for (uint32_t channelIdx = 0; channelIdx < maxChPerErxNonCM; channelIdx++) {
-              uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
-              digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::ZS_ADC;
-            }
             continue;
           }
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
@@ -214,12 +207,11 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
 
           // parse erx body (channel data)
           uint32_t iBit = 0;
-          for (uint32_t channelIdx = 0; channelIdx < maxChPerErxNonCM; channelIdx++) {
+          for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
 
             // check if the channel has data
             if (((erxHeader >> channelIdx) & 1) == 0) {
-              digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::ZS_ADC;
               continue;
             }
 
@@ -249,10 +241,6 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
         for (uint32_t erxIdx = 0; erxIdx < erxMax; erxIdx++) {
           // check if the eRx is enabled
           if ((enabledErx >> erxIdx & 1) == 0) {
-            for (uint32_t channelIdx = 0; channelIdx < maxChPerErxNonCM; channelIdx++) {
-              uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
-              digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::Inactive;
-            }
             continue;
           }
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
@@ -274,12 +262,11 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
           iword += 2;
 
           // parse erx body (channel data)
-          for (uint32_t channelIdx = 0; channelIdx < maxChPerErxNonCM; channelIdx++) {
+          for (uint32_t channelIdx = 0; channelIdx < HGCalMappingCellIndexer::maxChPerErx_; channelIdx++) {
             uint32_t denseIdx = moduleIndexer.getIndexForModuleData(fedId, globalECONDIdx, erxIdx, channelIdx);
 
             // check if the channel has data
             if (((erxHeader >> channelIdx) & 1) == 0) {
-              digis.view()[denseIdx].flags() = hgcal::DIGI_FLAG::Inactive;
               continue;
             }
 


### PR DESCRIPTION
This PR is to fix the issue defined https://gitlab.cern.ch/hgcal-dpg/hgcal-comm/-/issues/3

The flag is defined as:

> No zero-suppression in digi: 0x0000
> Only ADC(-1) is zero-suppressed in digi: 0x0001
> Only ToA is zero-suppressed in digi: 0x0002,
> ToA and ADCm1 are zero-suppressed in digi: 0x0003,
> The whole digi is zero-suppressed: 0x0004,
> Digi with invalid TcTp: 0x0005