### PR TITLE
bugfix in the cm Sum

### DIFF
--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -199,7 +199,7 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
 
           // erx header
           uint16_t cmSum = ((econd_payload[iword] >> ECOND_FRAME::COMMONMODE0_POS) & ECOND_FRAME::COMMONMODE0_MASK) +
-                           ((econd_payload[iword + 1] >> ECOND_FRAME::COMMONMODE1_POS) & ECOND_FRAME::COMMONMODE1_MASK);
+                           ((econd_payload[iword] >> ECOND_FRAME::COMMONMODE1_POS) & ECOND_FRAME::COMMONMODE1_MASK);
           uint64_t erxHeader = ((uint64_t)econd_payload[iword] << 32) | ((uint64_t)econd_payload[iword + 1]);
           LogDebug("[HGCalUnpacker]") << "erx_headers = 0x" << std::hex << std::setfill('0') << std::setw(16)
                                       << erxHeader << ", cmSum = " << std::dec << cmSum;
@@ -255,7 +255,7 @@ void HGCalUnpacker::parseFEDData(unsigned fedId,
 
           // erx header
           uint16_t cmSum = ((econd_payload[iword] >> ECOND_FRAME::COMMONMODE0_POS) & ECOND_FRAME::COMMONMODE0_MASK) +
-                           ((econd_payload[iword + 1] >> ECOND_FRAME::COMMONMODE1_POS) & ECOND_FRAME::COMMONMODE1_MASK);
+                           ((econd_payload[iword] >> ECOND_FRAME::COMMONMODE1_POS) & ECOND_FRAME::COMMONMODE1_MASK);
           uint64_t erxHeader = ((uint64_t)econd_payload[iword] << 32) | ((uint64_t)econd_payload[iword + 1]);
           LogDebug("[HGCalUnpacker]") << "erx_headers = 0x" << std::hex << std::setfill('0') << std::setw(16)
                                       << erxHeader << ", cmSum = " << std::dec << cmSum;


### PR DESCRIPTION
The index of getting the first common mode is set wrongly to the the next word of first word of eRx header, this typically will go into the channel map.

In the context of test beam, the channel map would be 37 bits of 1 in most scenario, thus this would cause the cmSum=cm0+1023, and give unphysical result
