### PR TITLE
Unpacker update

### DIFF
--- a/DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoSoA.h
+++ b/DataFormats/HGCalDigi/interface/HGCalECONDPacketInfoSoA.h
@@ -12,6 +12,8 @@
 
 namespace hgcaldigi {
 
+  // use Matrix for common modes
+  using Matrix = Eigen :: Matrix < uint16_t , 12 , 2 >;
   // enum for getting ECONDFlag
   namespace ECONDFlag {
     constexpr uint8_t BITT_POS = 0, BITM_POS = 1, EBO_POS = 2, EBO_MASK = 0b11, HT_POS = 4, HT_MASK = 0b11,
@@ -67,7 +69,8 @@ namespace hgcaldigi {
                       // Payload length
                       // If exception found before ECON-D, this would be 0
                       // Otherwise the payload length of the ECON-D
-                      SOA_COLUMN(uint16_t, payloadLength))
+                      SOA_COLUMN(uint16_t, payloadLength),
+                      SOA_EIGEN_COLUMN(Matrix, cm))
   using HGCalECONDPacketInfoSoA = HGCalECONDPacketInfoSoALayout<>;
 }  // namespace hgcaldigi
 

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -340,7 +340,6 @@ uint8_t HGCalUnpacker::parseFEDData(unsigned fedId,
   if (ptr + 2 != trailer) {
     uint32_t ECONDdenseIdx = moduleIndexer.getIndexForModule(fedId, 0);
     econdPacketInfo.view()[ECONDdenseIdx].exception() = 6;
-    econdPacketInfo.view()[ECONDdenseIdx].location() = 0;
     edm::LogWarning("[HGCalUnpacker]") << "Error finding the S-link trailer, expected at" << std::dec
                                        << (uint32_t)(trailer - header) << "/0x" << std::hex
                                        << (uint32_t)(trailer - header) << "Unpacked trailer at" << std::dec

--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpacker.cc
@@ -206,6 +206,8 @@ uint8_t HGCalUnpacker::parseFEDData(unsigned fedId,
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
                                       << ", econdIdx = " << econdIdx << ", erxIdx=" << erxIdx;
 
+          econdPacketInfo.view()[ECONDdenseIdx].cm()(erxIdx,0) = (econd_payload[iword] >> ECOND_FRAME::COMMONMODE0_POS) & ECOND_FRAME::COMMONMODE0_MASK;
+          econdPacketInfo.view()[ECONDdenseIdx].cm()(erxIdx,1) = (econd_payload[iword] >> ECOND_FRAME::COMMONMODE1_POS) & ECOND_FRAME::COMMONMODE1_MASK;
           // check if the eRx sub-packet is empty (the "F" flag in the eRx sub-packet header)
           if (((econd_payload[iword] >> ECOND_FRAME::ERXFORMAT_POS) & ECOND_FRAME::ERXFORMAT_MASK) == 1) {
             LogDebug("[HGCalUnpacker]") << "eRx " << erxIdx << " is empty";
@@ -262,6 +264,8 @@ uint8_t HGCalUnpacker::parseFEDData(unsigned fedId,
           LogDebug("[HGCalUnpacker]") << "fedId = " << fedId << ", captureblockIdx = " << captureblockIdx
                                       << ", econdIdx = " << econdIdx << ", erxIdx=" << erxIdx;
 
+          econdPacketInfo.view()[ECONDdenseIdx].cm()(erxIdx,0) = (econd_payload[iword] >> ECOND_FRAME::COMMONMODE0_POS) & ECOND_FRAME::COMMONMODE0_MASK;
+          econdPacketInfo.view()[ECONDdenseIdx].cm()(erxIdx,1) = (econd_payload[iword] >> ECOND_FRAME::COMMONMODE1_POS) & ECOND_FRAME::COMMONMODE1_MASK;
           // check if the eRx sub-packet is empty (the "F" flag in the eRx sub-packet header)
           if (((econd_payload[iword] >> ECOND_FRAME::ERXFORMAT_POS) & ECOND_FRAME::ERXFORMAT_MASK) == 1) {
             LogDebug("[HGCalUnpacker]") << "eRx " << erxIdx << " is empty";


### PR DESCRIPTION
This pull request aims at solving the issue [Parallelize unpacking per FED](https://gitlab.cern.ch/hgcal-dpg/hgcal-comm/-/issues/21) and [Monitor CM for ZS runs](https://gitlab.cern.ch/hgcal-dpg/hgcal-comm/-/issues/34)

Parallelizing unpacking per FED is applied using `tbb::parallel_for` in commit ae4bf46dbb6b28fdf1973b40702da9c0ee3e6162, the affect on timing is still needed to be checked

CM for runs with ZS is saved in a 12 by 2 matrix `cm`, the element `cm(i,j)` stands for j-th common mode in i-th eRx subpacket, N.B. that CM in not enabled eRx subpacket may contain garbage. This is in commit 1d27615b83d2a3d7326a3264fdb9cfa090d19fe2