### PR TITLE
Fix format of tile board typecode

### DIFF
--- a/Geometry/HGCalMapping/plugins/HGCalMappingESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/HGCalMappingESProducer.cc
@@ -111,7 +111,7 @@ void HGCalMappingESProducer::prepareModuleMapperIndexer() {
     if (matched) {
       wtypecode = typecode_match[1].str();  // wafer type following MM-T pattern, e.g. "MH-F"
     } else {
-      const std::regex sipm_typecode_regex(R"(T[LH]-L\d{2}S\d)");
+      const std::regex sipm_typecode_regex(R"(^T(.*)-L([0-9]+)S([0-9]+)-(.*)$)");
       std::smatch sipm_typecode_match;  // match object for string objects
       matched = std::regex_match(typecode, sipm_typecode_match, sipm_typecode_regex);
       if (matched) {

--- a/Geometry/HGCalMapping/plugins/HGCalMappingESProducer.cc
+++ b/Geometry/HGCalMapping/plugins/HGCalMappingESProducer.cc
@@ -111,7 +111,7 @@ void HGCalMappingESProducer::prepareModuleMapperIndexer() {
     if (matched) {
       wtypecode = typecode_match[1].str();  // wafer type following MM-T pattern, e.g. "MH-F"
     } else {
-      const std::regex sipm_typecode_regex(R"(^T(.*)-L([0-9]+)S([0-9]+)-(.*)$)");
+      const std::regex sipm_typecode_regex(R"(^T(.*)-L([0-9]+)S([0-9]+)(?:-(.*))?$)");
       std::smatch sipm_typecode_match;  // match object for string objects
       matched = std::regex_match(typecode, sipm_typecode_match, sipm_typecode_regex);
       if (matched) {


### PR DESCRIPTION
#### PR description:

This PR updates the format of the HGCAL tileboard typecode.

#### PR validation:

To be tested with TB2025 data with the tile boards in the silicon system.

Current run-time error:
```bash
# Origin of the message
# CondFormats/HGCalObjects/interface/HGCalMappingCellIndexer.h:57

----- Begin Fatal Exception 25-Nov-2025 10:40:25 CET-----------------------
An exception of category 'ValueError' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing ESSource: class=HGCalMappingESProducer label='hgCalMappingESProducer'
Exception Message:
 unable to find typecode=TL-L44S1-TB2025 in cell indexer
----- End Fatal Exception -------------------------------------------------
```

Build commands tweaked from mini-hackathon procedure:
```
export SCRAM_ARCH=el9_amd64_gcc13
cmsrel CMSSW_16_0_0_pre1
cd CMSSW_16_0_0_pre1/src
cmsenv
git cms-merge-topic -u ywkao:dev/fix_modmix  # fix to module locator + update of local reco kernels
 
git clone https://gitlab.cern.ch/hgcal-dpg/hgcal-comm.git HGCalCommissioning
git remote add ykao ssh://git@gitlab.cern.ch:7999/ykao/hgcal-comm.git
git fetch ykao fix-fnal-sipm-display
git checkout fix-fnal-sipm-display

#optional (only if running local calibration routines)
python3 -m pip install -r HGCalCommissioning/requirements.txt --user

#Calibration files : WARNING **DO NOT** COPY PASTE THE FOLLOWING ALTOGETHER!!!
git clone --no-checkout https://gitlab.cern.ch/hgcal-dpg/calibrations.git HGCalCommissioning/Calibrations
cd HGCalCommissioning/Calibrations
git sparse-checkout set P5 TB2025
git reset --hard HEAD
cd -

#compile
scram b -j8
```