### PR TITLE
TPG BC low occupancy fix

### DIFF
--- a/EventFilter/HGCalRawToDigi/interface/TPG/Stage1IO.hh
+++ b/EventFilter/HGCalRawToDigi/interface/TPG/Stage1IO.hh
@@ -146,8 +146,9 @@ public:
       
       if(type==TPGFEDataformat::BestC) {
 	lastBit-=7;
-	unsigned idx = nTc - tc - 1; // assign first energy to lowest tc address
-	vTc[idx]=TPGFEDataformat::TcRawData(type,vTc[idx].address(),(d>>lastBit)&0x7f); 
+	unsigned idx = nTc - tc - 1; // to assign first energy to lowest tc address for high occupancy
+	if (bitMap) vTc[idx]=TPGFEDataformat::TcRawData(type,vTc[idx].address(),(d>>lastBit)&0x7f); 
+	else vTc[tc]=TPGFEDataformat::TcRawData(type,vTc[tc].address(),(d>>lastBit)&0x7f);
       } else if(type==TPGFEDataformat::STC4A) {
 	lastBit-=7;
 	vTc[tc]=TPGFEDataformat::TcRawData(type,vTc[tc].address(),(d>>lastBit)&0x7f);


### PR DESCRIPTION
#### PR description:

Fixed BC low occupancy assignment of energy to TC.

#### PR validation:
Tested on fixed ADC run of cassette era v9 118877.
Before (left DAQ, right TPG):
<img width="1226" height="508" alt="image" src="https://github.com/user-attachments/assets/74a529b9-14f4-43d2-80fc-a5ee24fa0ac1" />
After the fix  (left DAQ, right TPG):
<img width="1266" height="549" alt="image" src="https://github.com/user-attachments/assets/748f5e14-df0c-4a37-b0ce-cec5522e4c82" />
