### PR TITLE
TPG mux for HD modules

### DIFF
--- a/EventFilter/HGCalRawToDigi/src/HGCalUnpackerTrigger.cc
+++ b/EventFilter/HGCalRawToDigi/src/HGCalUnpackerTrigger.cc
@@ -298,18 +298,18 @@ bool HGCalUnpackerTrigger::parseFEDData(unsigned fedId,
                         //// How much of below will be **CONFIGURE** ed
                         for(unsigned itc(0) ; itc < rdp.size() ; itc++){
 
-                            //uint32_t tcidx = uint32_t(rdp.getTc(itc).address()); 
-                            uint32_t tcidx = itc;
+                            uint32_t tcidx = uint32_t(rdp.getTc(itc).address()); 
+                            //uint32_t tcidx = itc;
                             //uint32_t denseIdx = tcidx + fedReadoutSequence.TCOffsets_.at(econTId) ; //same as following function call
                             uint32_t denseIdxRaw = moduleIndexer.getIndexForModuleData(fedId, econTId, tcidx) ; // before any swapping
                             
                             // offset in 2 steps, first mux then econts 
-                            uint32_t tcMuxSwapOffset = econt_conf.tcMux[itc] - tcidx;
-                            uint32_t econtSwapOffset = fedConfig.econtSwapOffset[iecon];
-                            uint32_t denseIdxOffset =  tcMuxSwapOffset + econtSwapOffset; 
+                            int32_t tcMuxSwapOffset = econt_conf.tcMux[tcidx] - tcidx;
+                            int32_t econtSwapOffset = fedConfig.econtSwapOffset[iecon];
+                            int32_t denseIdxOffset =  tcMuxSwapOffset + econtSwapOffset; 
 
                             // get offset directly from config file
-                            //uint32_t denseIdxOffset =  econt_conf.offset[itc]; 
+                            //int32_t denseIdxOffset =  econt_conf.offset[tcidx]; 
 
                             uint32_t denseIdx = denseIdxRaw + denseIdxOffset; // applying offset accounting for TCs and econts swapping
 
@@ -325,7 +325,7 @@ bool HGCalUnpackerTrigger::parseFEDData(unsigned fedId,
                             digisTrigger.view()[denseIdx].TotE()(bx,0) = (rdp.type()==TPGFEDataformat::BestC)? uint32_t(TPGFEDataformat::TcRawData::Decode5E3M(rdp.moduleSum())) : totE ;
                             digisTrigger.view()[denseIdx].TCEnergy()(bx,0) = uint32_t(rdp.getTc(itc).decodedE(rdp.type()) << cfgecont.getDropLSB());
                             digisTrigger.view()[denseIdx].encodedTCEnergy()(bx,0) = uint32_t(rdp.getTc(itc).energy());
-                            digisTrigger.view()[denseIdx].TCAddress()(bx,0) = uint8_t(rdp.getTc(itc).address());
+                            digisTrigger.view()[denseIdx].TCAddress()(bx,0) = uint8_t(rdp.getTc(itc).address() + tcMuxSwapOffset );
 
                             //if (bx == 3 && (tsh->nextSubpacketHeader())->channelId()%2!=0 ) {
                             if (bx == 3 ) {


### PR DESCRIPTION
#### PR description:

Fixing TPG mux offset calculation and application for HD modules, to match the mux applied in DAQ (see https://github.com/cms-sw/cmssw/pull/50644).
This fix follows observation made with fixed adc run for P5 cassette, see: https://indico.cern.ch/event/1712610/?note=394095#1-thursday-23-jul-2026

#### PR validation:

After fix, patterns of DAQ and TPG are in good agreement (fixed adc run cassette P5 era v11 118877):
<img width="1384" height="620" alt="image" src="https://github.com/user-attachments/assets/fdb44b6d-88ba-44c3-9086-c1b989122627" />

